### PR TITLE
Fix wrong dependency version

### DIFF
--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -21,7 +21,7 @@ publish = true
 default = []
 
 [dependencies]
-enso-prelude = { version = "0.1.4" , path = "../prelude"      }
+enso-prelude = { version = "0.1.5" , path = "../prelude"      }
 enso-shapely = { version = "0.1.1" , path = "../shapely/impl" }
 wasm-bindgen = { version = "=0.2.58", features = ["nightly"]  }
 


### PR DESCRIPTION
### Pull Request Description
The enso-logger crate use the new structure form enso-prelude, however version in dependency list wasn't bumped.

### Important Notes
Is there any way to test this before merging to main and publishing packages?

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
