### PR TITLE
Extract the Flexer to a Library

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,6 +38,12 @@ labels:
   - name: "Category: Data"
     color: "#d1f0fd"
     description: The data library
+  - name: "Category: Flexer"
+    color: "#d1f0fd"
+    description: The Flexer library
+  - name: "Category: Generics"
+    color: "#d1f0fd"
+    description: The generics library
   - name: "Category: Generics"
     color: "#d1f0fd"
     description: The generics library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@
 members = [
     "src/automata",
     "src/data",
+    "src/flexer",
+    "src/flexer-testing/definition",
+    "src/flexer-testing/generation",
     "src/generics",
     "src/lazy-reader",
     "src/logger",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+---
+layout: developer-doc
+title: Contributing to the Enso Rust Libraries
+category: summary
+tags: [summary, contributing]
+order: 1
+---
+
 # Contributing to This Repository
 
 Thank you for your interest in contributing to these libraries! We believe that

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+---
+layout: docs-index
+title: Enso Rust Libraries Developer Documentation
+category: summary
+tags: [summary, readme]
+order: 0
+---
+
+# Enso Rust Libraries Developer Documentation
+
+This folder contains the documentation for the implementation of the various
+libraries contained within this repo. The documentation is broken up by library
+and each folder contains information about the design, specification, and
+implementation of the library to which it pertains.
+
+We provide a number of useful resources for getting a quick understanding of the
+Enso rust libraries project:
+
+- [**Contributing Guidelines:**](./CONTRIBUTING.md) Information for people
+  wanting to contribute to these libraries (in many different ways).
+- [**Security Guidelines:**](./SECURITY.md) Security guidelines for the Enso
+  project, including supported versions and our vulnerability reporting process.
+
+It is broken up into categories as follows:
+
+- [**Flexer:**](./flexer) Information on the design of the flexer, a fast,
+  finite-automaton-based lexing engine.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,3 +1,11 @@
+---
+layout: developer-doc
+title: Security Policy
+category: summary
+tags: [summary, security, vulnerability, report]
+order: 2
+---
+
 # Security Policy
 
 This document outlines the security policy for all of the libraries in this
@@ -16,8 +24,8 @@ repository.
 
 ## Supported Versions
 
-Security updates for Enso are provided for the versions shown below with a
-:white_check_mark: next to them. No other versions have security updates
+Security updates for these libraries are provided for the versions shown below
+with a :white_check_mark: next to them. No other versions have security updates
 provided.
 
 | Version          | Supported          |

--- a/docs/flexer/README.md
+++ b/docs/flexer/README.md
@@ -1,0 +1,20 @@
+---
+layout: docs-index
+title: Enso's Parser
+category: summary
+tags: [parser, readme]
+order: 0
+---
+
+# The Flexer
+
+The flexer is a finite-automaton-based engine for the generation of
+highly-efficient lexers. It is capable of supporting the lexing of unrestricted
+grammars as it provides the author with the ability to manipulate the lexing
+state after every match.
+
+The various components of the flexer's design and architecture are described
+below:
+
+- [**Overview of the Flexer:**](./flexer.md) A brief overview of the flexer,
+  including what it is and how it works.

--- a/docs/flexer/flexer.md
+++ b/docs/flexer/flexer.md
@@ -1,0 +1,199 @@
+---
+layout: developer-doc
+title: Flexer
+category: syntax
+tags: [parser, flexer, lexer, dfa]
+order: 1
+---
+
+# Flexer
+
+The flexer is a finite-automata-based engine for the definition and generation
+of lexers. Akin to `flex`, and other lexer generators, the user may use it to
+define a series of rules for lexing their language, which are then used by the
+flexer to generate a highly-efficient lexer implementation.
+
+Where the flexer differs from other programs in this space, however, is the
+power that it gives users. When matching a rule, the flexer allows its users to
+execute _arbitrary_ Rust code, which may even manipulate the lexer's state and
+position. This means that the languages that can be lexed by the flexer extend
+from the simplest regular grammars right up to unrestricted grammars (but please
+don't write a programming language whose syntax falls into this category). It
+also differs in that it chooses the first complete match for a rule, rather than
+the longest one, which makes lexers much easier to define and maintain.
+
+For detailed library documentation, please see the
+[crate documentation](../../lib/rust/flexer/src/lib.rs) itself. This includes a
+comprehensive tutorial on how to define a lexer using the flexer.
+
+<!-- MarkdownTOC levels="2,3" autolink="true" -->
+
+- [The Lexing Process](#the-lexing-process)
+- [Lexing Rules](#lexing-rules)
+  - [Groups](#groups)
+  - [Patterns](#patterns)
+  - [Transition Functions](#transition-functions)
+- [Code Generation](#code-generation)
+  - [Automated Code Generation](#automated-code-generation)
+- [Structuring the Flexer Code](#structuring-the-flexer-code)
+  - [Supporting Code Generation](#supporting-code-generation)
+
+<!-- /MarkdownTOC -->
+
+## The Lexing Process
+
+In the flexer, the lexing process proceeds from the top to the bottom of the
+user-defined rules, and selects the first expression that _matches fully_. Once
+a pattern has been matched against the input, the associated code is executed
+and the process starts again until the input stream has been consumed.
+
+This point about _matching fully_ is particularly important to keep in mind, as
+it differs from other lexer generators that tend to prefer the _longest_ match
+instead.
+
+## Lexing Rules
+
+A lexing rule for the flexer is a combination of three things:
+
+1.  A group.
+2.  A pattern.
+3.  A transition function.
+
+An example of defining a rule is as follows:
+
+```rust
+fn define() -> Self {
+    let mut lexer     = TestLexer::new();
+    let a_word        = Pattern::char('a').many1();
+    let root_group_id = lexer.initial_state;
+    let root_group    = lexer.groups_mut().group_mut(root_group_id);
+    // Here is the rule definition.
+    root_group.create_rule(&a_word,"self.on_first_word(reader)");
+    lexer
+}
+```
+
+### Groups
+
+A group is a mechanism that the flexer provides to allow grouping of rules
+together. The flexer has a concept of a "state stack", which records the
+currently active state at the current time, that can be manipulated by the
+user-defined [transition functions](#transition-functions).
+
+A state can be made active by using `flexer::push_state(state)`, and can be
+deactivated by using `flexer::pop_state(state)` or
+`flexer::pop_states_until(state)`. In addition, states may also have _parents_,
+from which they can inherit rules. This is fantastic for removing the need to
+repeat yourself when defining the lexer.
+
+When inheriting rules from a parent group, the rules from the parent group are
+matched strictly _after_ the rules from the child group. This means that groups
+are able to selectively "override" the rules of their parents. Rules are still
+matched in order for each group's set of rules.
+
+### Patterns
+
+Rules are defined to match _patterns_. Patterns are regular-grammar-like
+descriptions of the textual content (as characters) that should be matched. For
+a description of the various patterns provided by the flexer, see
+[pattern.rs](../../lib/rust/flexer/src/automata/pattern.rs).
+
+When a pattern is matched, the associated
+[transition function](#transition-functions) is executed.
+
+### Transition Functions
+
+The transition function is a piece of arbitrary rust code that is executed when
+the pattern for a given rule is matched by the flexer. This code may perform
+arbitrary manipulations of the lexer state, and is where the majority of the
+power of the flexer stems from.
+
+## Code Generation
+
+While it would be possible to interpret the flexer definition directly at
+runtime, this would involve far too much dynamicism and non-cache-local lookup
+to be at all fast.
+
+Instead, the flexer includes
+[`generate.rs`](../../lib/rust/flexer/src/generate.rs), a library for generating
+highly-specialized lexer implementations based on the definition provided by the
+user. The transformation that it implements operates as follows for each group
+of rules.
+
+1.  The set of rules in a group is used to generate a
+    [Nondeterministic Finite Automaton](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton),
+    (NFA).
+2.  The NFA is ttransformed into a
+    [Deterministic Finite Automaton](https://en.wikipedia.org/wiki/Deterministic_finite_automaton)
+    (DFA), using a variant of the standard
+    [powerset construction](https://en.wikipedia.org/wiki/Powerset_construction)
+    algorithm. This variant has been modified to ensure that the following
+    additional properties hold:
+    - Patterns are matched in the order in which they are defined.
+    - The associated transition functions are maintained correctly through the
+      transformation.
+    - The lexing process is `O(n)`, where `n` is the size of the input.
+3.  The DFA is then used to generate the rust code that implements that lexer.
+
+The generated lexer contains a main loop that consumes the input stream
+character-by-character, evaluating what is effectively a big `match` expression
+that processes the input to evaluate the user-provided transition functions as
+appropriate.
+
+### Automated Code Generation
+
+In order to avoid the lexer definition getting out of sync with its
+implementation (the generated engine), it is necessary to create a separate
+crate for the generated engine that has the lexer definition as one of its
+dependencies.
+
+This separation enables a call to `flexer::State::specialize()` in the crate's
+`build.rs` (or a macro) during compilation. The output can be stored in a new
+file i.e. `engine.rs` and exported from the library as needed. The project
+structure would therefore appear as follows.
+
+```
+- lib/rust/lexer/
+  - definition/
+    - src/
+      - lib.rs
+    - cargo.toml
+
+  - generation/
+    - src/
+      - engine.rs <-- the generated file
+      - lib.rs    <-- `pub mod engine`
+    - build.rs    <-- calls `flexer::State::specialize()` and saves its output to
+                      `src/engine.rs`
+    - cargo.toml <-- lexer-definition is in dependencies and build-dependencies
+```
+
+With this design, `flexer.generate_specialized_code()` is going to be executed
+on each rebuild of `lexer/generation`. Therefore, `generation` should contain
+only the minimum amount of logic, and should endeavor to minimize any
+unnecessary dependencies to avoid recompiling too often.
+
+## Structuring the Flexer Code
+
+In order to unify the API between the definition and generated usages of the
+flexer, the API is separated into the following components:
+
+- `Flexer`: The main flexer definition itself, providing functionality common to
+  the definition and implementation of all lexers.
+- `flexer::State`: The stateful components of a lexer definition. This trait is
+  implemented for a particular lexer definition, allowing the user to store
+  arbitrary data in their lexer, as needed.
+- **User-Defined Lexer:** The user can then define a lexer that _wraps_ the
+  flexer, specialised to the particular `flexer::State` that the user has
+  defined. It is recommended to implement `Deref` and `DerefMut` between the
+  defined lexer and the `Flexer`, to allow for ease of use.
+
+### Supporting Code Generation
+
+This architecture separates out the generated code (which can be defined purely
+on the user-defined lexer), from the code that is defined as part of the lexer
+definition. This means that the same underlying structures can be used to both
+_define_ the lexer, and be used by the generated code from that definition.
+
+For an example of how these components are used in the generated lexer, please
+see [`generated_api_test`](../../lib/rust/flexer/tests/generated_api_test.rs).

--- a/run
+++ b/run
@@ -5,6 +5,7 @@ const spawnSync = require('child_process').spawnSync
 const path      = require('path')
 
 const libImplDirName = 'impl'
+const srcDirName     = 'src'
 
 let args = process.argv.slice(2)
 
@@ -18,21 +19,24 @@ function runSync(cmd, args) {
 
 function testLibrary() {
     cwd = process.cwd()
-    console.log(`In directory ${cwd}`)
-
     containedDirs = fss.readdirSync(cwd, {withFileTypes: true})
         .filter(f => f.isDirectory())
         .map(d => d.name)
 
-    if (containedDirs.includes(libImplDirName)) {
-        process.chdir(path.join(cwd, libImplDirName))
+    if (containedDirs.includes(srcDirName)) {
+        console.log(`In directory ${cwd}`)
+        runSync('wasm-pack',['test', '--node'])
+    } else if (containedDirs.includes(libImplDirName)) {
+        let new_dir = path.join(cwd,libImplDirName)
+        withCwd(new_dir, () => testLibrary())
+    } else {
+        let deeperDirs = containedDirs.map(d => path.join(cwd, d))
+        deeperDirs.forEach(d => withCwd(d, testLibrary))
     }
-
-    runSync('wasm-pack', ['test', '--node'])
 }
 
 async function withCwd(dir, fn) {
-    let cwd = path.dirname(__filename)
+    let cwd = process.cwd()
     process.chdir(dir)
     let out = await fn()
     process.chdir(cwd)

--- a/src/flexer-testing/definition/Cargo.toml
+++ b/src/flexer-testing/definition/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name    = "flexer-test-definition"
+version = "0.1.0"
+authors = ["Enso Team <enso-dev@enso.org>"]
+edition = "2018"
+
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+test       = true
+bench      = true
+
+[dependencies]
+enso-flexer = { version = "0.1.0", path = "../../flexer" }

--- a/src/flexer-testing/definition/src/lib.rs
+++ b/src/flexer-testing/definition/src/lib.rs
@@ -1,0 +1,282 @@
+#![deny(unconditional_recursion)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+//! This file contains the code defining a lexer for the following small language. Due to the way in
+//! which the code-generation from the flexer is used, it has to be defined in a separate crate from
+//! the site at which it's used. For the actual tests of this code, please see
+//! `flexer-testing/generation`.
+//!
+//! The language here is being defined as follows:
+//!
+//! a-word      = 'a'+;
+//! b-word      = 'b'+;
+//! word        = a-word | b-word;
+//! space       = ' ';
+//! spaced-word = space, word;
+//! language    = word, spaced-word*;
+//!
+//! Please note that there is a fair amount of duplicated code between this test and the
+//! `lexer_generated_api_test` file. This is to present the full view of what each portion of the
+//! process looks like.
+
+use enso_flexer::*;
+use enso_flexer::prelude::*;
+
+use enso_flexer;
+use enso_flexer::automata::pattern::Pattern;
+use enso_flexer::group::Registry;
+use enso_flexer::prelude::logger::Disabled;
+use enso_flexer::prelude::reader::BookmarkManager;
+
+
+
+// ====================
+// === Type Aliases ===
+// ====================
+
+type Logger = Disabled;
+
+
+
+// ===========
+// === AST ===
+// ===========
+
+/// A very simple AST, sufficient for the simple language being defined.
+#[derive(Clone,Debug,PartialEq)]
+pub enum Token {
+    /// A word from the input, consisting of a sequence of all `a` or all `b`.
+    Word(String),
+    /// A token that the lexer is unable to recognise.
+    Unrecognized(String),
+}
+impl Token {
+    /// Construct a new word token.
+    pub fn word(name:impl Into<String>) -> Token {
+        Token::Word(name.into())
+    }
+
+    /// Construct a new unrecognized token.
+    pub fn unrecognized(name:impl Into<String>) -> Token {
+        Token::Unrecognized(name.into())
+    }
+}
+
+/// A representation of a stream of tokens.
+#[allow(missing_docs)]
+#[derive(Clone,Debug,Default,PartialEq)]
+pub struct TokenStream {
+    tokens:Vec<Token>
+}
+
+impl TokenStream {
+    /// Append the provided token to the token stream.
+    pub fn push(&mut self,token:Token) {
+        self.tokens.push(token);
+    }
+}
+
+
+// === Trait Impls ===
+
+impl From<Vec<Token>> for TokenStream {
+    fn from(tokens: Vec<Token>) -> Self {
+        TokenStream {tokens}
+    }
+}
+
+
+
+// ==================
+// === Test Lexer ===
+// ==================
+
+/// The definition of a test lexer for the above-described language.
+#[derive(Debug)]
+pub struct TestLexer {
+    lexer:Flexer<TestState,TokenStream,Logger>
+}
+
+impl Deref for TestLexer {
+    type Target = Flexer<TestState,TokenStream,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for TestLexer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl TestLexer {
+    /// Creates a new instance of this lexer.
+    pub fn new() -> Self {
+        let logger = Logger::new("TestLexer");
+        let lexer  = Flexer::new(logger);
+        TestLexer{lexer}
+    }
+}
+
+/// Rules for the root state.
+#[allow(dead_code,missing_docs)]
+impl TestLexer {
+    fn on_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(str);
+        self.output.push(ast);
+        let id = self.seen_first_word_state;
+        self.push_state(id);
+    }
+
+    fn on_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let ast = Token::Unrecognized(self.current_match.clone());
+        self.output.push(ast);
+    }
+
+    fn on_no_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {}
+
+    fn rules_in_root(lexer:&mut TestLexer) {
+        let a_word        = Pattern::char('a').many1();
+        let b_word        = Pattern::char('b').many1();
+        let any           = Pattern::any();
+        let end           = Pattern::eof();
+
+        let root_group_id = lexer.initial_state;
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+
+        root_group.create_rule(&a_word,"self.on_first_word(reader)");
+        root_group.create_rule(&b_word,"self.on_first_word(reader)");
+        root_group.create_rule(&end,   "self.on_no_err_suffix_first_word(reader)");
+        root_group.create_rule(&any,   "self.on_err_suffix_first_word(reader)");
+    }
+}
+
+/// Rules for the "seen first word" state.
+#[allow(dead_code,missing_docs)]
+impl TestLexer {
+    fn on_spaced_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(String::from(str.trim()));
+        self.output.push(ast);
+    }
+
+    fn on_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+        self.on_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn on_no_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+        self.on_no_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn rules_in_seen_first_word(lexer:&mut TestLexer) {
+        let a_word        = Pattern::char('a').many1();
+        let b_word        = Pattern::char('b').many1();
+        let space         = Pattern::char(' ');
+        let spaced_a_word = &space >> &a_word;
+        let spaced_b_word = &space >> &b_word;
+        let any           = Pattern::any();
+        let end           = Pattern::eof();
+
+        let seen_first_word_group_id = lexer.seen_first_word_state;
+        let seen_first_word_group    = lexer.groups_mut().group_mut(seen_first_word_group_id);
+
+        seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&end,          "self.on_no_err_suffix(reader)");
+        seen_first_word_group.create_rule(&any,          "self.on_err_suffix(reader)");
+    }
+}
+
+
+// === Trait Impls ===
+
+impl enso_flexer::Definition for TestLexer {
+    fn define() -> Self {
+        let mut lexer = TestLexer::new();
+
+        TestLexer::rules_in_seen_first_word(&mut lexer);
+        TestLexer::rules_in_root(&mut lexer);
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {}
+
+    fn tear_down(&mut self) {}
+}
+
+impl Default for TestLexer {
+    fn default() -> Self {
+        TestLexer::new()
+    }
+}
+
+
+
+// ===================
+// === Lexer State ===
+// ===================
+
+/// The stateful components of the test lexer.
+#[derive(Debug)]
+pub struct TestState {
+    /// The registry for groups in the lexer.
+    lexer_states:group::Registry,
+    /// The initial state of the lexer.
+    initial_state:group::Identifier,
+    /// The state entered when the first word has been seen.
+    seen_first_word_state:group::Identifier,
+    /// The bookmarks for this lexer.
+    bookmarks:BookmarkManager
+}
+
+
+// === Trait Impls ===
+
+impl enso_flexer::State for TestState {
+    fn new(_logger:&impl AnyLogger) -> Self {
+        let mut lexer_states      = group::Registry::default();
+        let initial_state         = lexer_states.define_group("ROOT",None);
+        let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+        let bookmarks             = BookmarkManager::new();
+        Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+    }
+
+    fn initial_state(&self) -> group::Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &group::Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut group::Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        &self.bookmarks
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        &mut self.bookmarks
+    }
+
+    fn specialize(&self) -> Result<String,GenError> {
+        generate::specialize(self,"TestLexer","TokenStream")
+    }
+}

--- a/src/flexer-testing/generation/Cargo.toml
+++ b/src/flexer-testing/generation/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name    = "flexer-test-generation"
+version = "0.1.0"
+authors = ["Enso Team <enso-dev@enso.org>"]
+edition = "2018"
+
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+test       = true
+bench      = true
+
+[dependencies]
+enso-flexer            = { version = "0.1.0", path = "../../flexer"  }
+flexer-test-definition = { version = "0.1.0", path = "../definition" }
+
+[build-dependencies]
+enso-flexer            = { version = "0.1.0", path = "../../flexer"  }
+flexer-test-definition = { version = "0.1.0", path = "../definition" }

--- a/src/flexer-testing/generation/build.rs
+++ b/src/flexer-testing/generation/build.rs
@@ -1,0 +1,32 @@
+use std::fs::File;
+use std::io::prelude::*;
+use flexer_test_definition::TestLexer;
+use enso_flexer::Definition;
+use enso_flexer::State;
+
+
+
+/// Generates the lexer engine and saves the result into the file `src/engine.rs`.
+///
+/// The content of the generated file can be used with the `include!` macro.
+fn generate_engine() -> std::io::Result<()> {
+    let definition_path  = "../definition/src/lib.rs";
+    let output_directory = "src/generated";
+    let _                = std::fs::create_dir(output_directory);
+    let output_path      = "src/generated/engine.rs";
+    let definition_error = format!("The lexer definition should exist at {}.",definition_path);
+    let output_error     = format!("Cannot open output file at {}.",output_path);
+    let mut lexer_def    = File::open(definition_path).expect(definition_error.as_str());
+    let mut contents     = String::new();
+    let mut file         = File::create(output_path).expect(output_error.as_str());
+    let lexer            = TestLexer::define();
+    let engine           = lexer.specialize().unwrap();
+    lexer_def.read_to_string(&mut contents).expect("Unable to read lexer definition.");
+    file.write_all(contents.as_bytes()).expect("Unable to write lexer definition.");
+    file.write_all(engine.as_bytes()).expect("Unable to write lexer specialization.");
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    generate_engine()
+}

--- a/src/flexer-testing/generation/src/generated.rs
+++ b/src/flexer-testing/generation/src/generated.rs
@@ -1,0 +1,3 @@
+//! This module serves to re-export the generated lexer.
+
+pub mod engine;

--- a/src/flexer-testing/generation/src/generated/engine-old.rs
+++ b/src/flexer-testing/generation/src/generated/engine-old.rs
@@ -1,0 +1,632 @@
+#![deny(unconditional_recursion)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+//! This file contains the code defining a lexer for the following small language. Due to the way in
+//! which the code-generation from the flexer is used, it has to be defined in a separate crate from
+//! the site at which it's used. For the actual tests of this code, please see
+//! `flexer-testing/generation`.
+//!
+//! The language here is being defined as follows:
+//!
+//! a-word      = 'a'+;
+//! b-word      = 'b'+;
+//! word        = a-word | b-word;
+//! space       = ' ';
+//! spaced-word = space, word;
+//! language    = word, spaced-word*;
+//!
+//! Please note that there is a fair amount of duplicated code between this test and the
+//! `lexer_generated_api_test` file. This is to present the full view of what each portion of the
+//! process looks like.
+
+use flexer::prelude::*;
+
+use flexer;
+use flexer::automata::pattern::Pattern;
+use flexer::group::Registry;
+use flexer::prelude::logger::Disabled;
+use flexer::prelude::reader::BookmarkManager;
+use flexer::*;
+
+// ====================
+// === Type Aliases ===
+// ====================
+
+type Logger = Disabled;
+
+// ===========
+// === AST ===
+// ===========
+
+/// A very simple AST, sufficient for the simple language being defined.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Token {
+    /// A word from the input, consisting of a sequence of all `a` or all `b`.
+    Word(String),
+    /// A token that the lexer is unable to recognise.
+    Unrecognized(String),
+}
+
+impl Token {
+    /// Construct a new word token.
+    pub fn word(name: impl Into<String>) -> Token {
+        Token::Word(name.into())
+    }
+
+    /// Construct a new unrecognized token.
+    pub fn unrecognized(name: impl Into<String>) -> Token {
+        Token::Unrecognized(name.into())
+    }
+}
+
+/// A representation of a stream of tokens.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TokenStream {
+    tokens: Vec<Token>,
+}
+
+impl TokenStream {
+    /// Append the provided token to the token stream.
+    pub fn push(&mut self, token: Token) {
+        self.tokens.push(token);
+    }
+}
+
+// === Trait Impls ===
+
+impl From<Vec<Token>> for TokenStream {
+    fn from(tokens: Vec<Token>) -> Self {
+        TokenStream { tokens }
+    }
+}
+
+// ==================
+// === Test Lexer ===
+// ==================
+
+/// The definition of a test lexer for the above-described language.
+#[derive(Debug)]
+pub struct TestLexer {
+    lexer: Flexer<TestState, TokenStream, Logger>,
+}
+
+impl Deref for TestLexer {
+    type Target = Flexer<TestState, TokenStream, Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for TestLexer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl TestLexer {
+    /// Creates a new instance of this lexer.
+    pub fn new() -> Self {
+        let logger = Logger::new("TestLexer");
+        let lexer = Flexer::new(logger);
+        TestLexer { lexer }
+    }
+}
+
+/// Rules for the root state.
+#[allow(dead_code, missing_docs)]
+impl TestLexer {
+    fn on_first_word<R: LazyReader>(&mut self, _reader: &mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(str);
+        self.output.push(ast);
+        let id = self.seen_first_word_state;
+        self.push_state(id);
+    }
+
+    fn on_err_suffix_first_word<R: LazyReader>(&mut self, _reader: &mut R) {
+        let ast = Token::Unrecognized(self.current_match.clone());
+        self.output.push(ast);
+    }
+
+    fn on_no_err_suffix_first_word<R: LazyReader>(&mut self, _reader: &mut R) {}
+
+    fn rules_in_root(lexer: &mut TestLexer) {
+        let a_word = Pattern::char('a').many1();
+        let b_word = Pattern::char('b').many1();
+        let any = Pattern::any();
+        let end = Pattern::eof();
+
+        let root_group_id = lexer.initial_state;
+        let root_group = lexer.groups_mut().group_mut(root_group_id);
+
+        root_group.create_rule(&a_word, "self.on_first_word(reader)");
+        root_group.create_rule(&b_word, "self.on_first_word(reader)");
+        root_group.create_rule(&end, "self.on_no_err_suffix_first_word(reader)");
+        root_group.create_rule(&any, "self.on_err_suffix_first_word(reader)");
+    }
+}
+
+/// Rules for the "seen first word" state.
+#[allow(dead_code, missing_docs)]
+impl TestLexer {
+    fn on_spaced_word<R: LazyReader>(&mut self, _reader: &mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(String::from(str.trim()));
+        self.output.push(ast);
+    }
+
+    fn on_err_suffix<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn on_no_err_suffix<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_no_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn rules_in_seen_first_word(lexer: &mut TestLexer) {
+        let a_word = Pattern::char('a').many1();
+        let b_word = Pattern::char('b').many1();
+        let space = Pattern::char(' ');
+        let spaced_a_word = &space >> &a_word;
+        let spaced_b_word = &space >> &b_word;
+        let any = Pattern::any();
+        let end = Pattern::eof();
+
+        let seen_first_word_group_id = lexer.seen_first_word_state;
+        let seen_first_word_group = lexer.groups_mut().group_mut(seen_first_word_group_id);
+
+        seen_first_word_group.create_rule(&spaced_a_word, "self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&spaced_b_word, "self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&end, "self.on_no_err_suffix(reader)");
+        seen_first_word_group.create_rule(&any, "self.on_err_suffix(reader)");
+    }
+}
+
+// === Trait Impls ===
+
+impl flexer::Definition for TestLexer {
+    fn define() -> Self {
+        let mut lexer = TestLexer::new();
+
+        TestLexer::rules_in_seen_first_word(&mut lexer);
+        TestLexer::rules_in_root(&mut lexer);
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {}
+
+    fn tear_down(&mut self) {}
+}
+
+impl Default for TestLexer {
+    fn default() -> Self {
+        TestLexer::new()
+    }
+}
+
+// ===================
+// === Lexer State ===
+// ===================
+
+/// The stateful components of the test lexer.
+#[derive(Debug)]
+pub struct TestState {
+    /// The registry for groups in the lexer.
+    lexer_states: group::Registry,
+    /// The initial state of the lexer.
+    initial_state: group::Identifier,
+    /// The state entered when the first word has been seen.
+    seen_first_word_state: group::Identifier,
+    /// The bookmarks for this lexer.
+    bookmarks: BookmarkManager,
+}
+
+// === Trait Impls ===
+
+impl flexer::State for TestState {
+    fn new(_logger: &impl AnyLogger) -> Self {
+        let mut lexer_states = group::Registry::default();
+        let initial_state = lexer_states.define_group("ROOT", None);
+        let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD", None);
+        let bookmarks = BookmarkManager::new();
+        Self {
+            lexer_states,
+            initial_state,
+            seen_first_word_state,
+            bookmarks,
+        }
+    }
+
+    fn initial_state(&self) -> group::Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &group::Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut group::Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        &self.bookmarks
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        &mut self.bookmarks
+    }
+
+    fn specialize(&self) -> Result<String, GenError> {
+        generate::specialize(self, "TestLexer", "TokenStream")
+    }
+}
+
+#[allow(missing_docs, dead_code, clippy::all)]
+impl TestLexer {
+    pub fn run<R: LazyReader>(&mut self, mut reader: R) -> LexingResult<TokenStream> {
+        self.set_up();
+        reader.advance_char(&mut self.bookmarks);
+        while self.run_current_state(&mut reader) == StageStatus::ExitSuccess {}
+        let result = match self.status {
+            StageStatus::ExitFinished => LexingResult::success(mem::take(&mut self.output)),
+            StageStatus::ExitFail => LexingResult::failure(mem::take(&mut self.output)),
+            _ => LexingResult::partial(mem::take(&mut self.output)),
+        };
+        self.tear_down();
+        result
+    }
+    fn run_current_state<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        self.status = StageStatus::Initial;
+        let mut finished = false;
+        while let Some(next_state) = self.status.continue_as() {
+            self.logger
+                .debug(|| format!("Current character is {:?}.", reader.character().char));
+            self.logger
+                .debug(|| format!("Continuing in {:?}.", next_state));
+            self.status = self.step(next_state, reader);
+            if finished && reader.finished(self.bookmarks()) {
+                self.logger.info("Input finished.");
+                self.status = StageStatus::ExitFinished
+            }
+            finished = reader.character().is_eof();
+            if self.status.should_continue() {
+                match reader.character().char {
+                    Ok(char) => {
+                        reader.append_result(char);
+                        self.logger
+                            .info(|| format!("Result is {:?}.", reader.result()));
+                    }
+                    Err(flexer::prelude::reader::Error::EOF) => {
+                        self.logger.info("Reached EOF.");
+                    }
+                    Err(flexer::prelude::reader::Error::EndOfGroup) => {
+                        let current_state = self.current_state();
+                        let group_name = self.groups().group(current_state).name.as_str();
+                        let err = format!("Missing rules for state {}.", group_name);
+                        self.logger.error(err.as_str());
+                        panic!(err)
+                    }
+                    Err(_) => {
+                        self.logger.error("Unexpected error!");
+                        panic!("Unexpected error!")
+                    }
+                }
+                reader.advance_char(&mut self.bookmarks);
+            }
+        }
+        self.status
+    }
+    fn step<R: LazyReader>(&mut self, next_state: SubStateId, reader: &mut R) -> StageStatus {
+        let current_state: usize = self.current_state().into();
+        match current_state {
+            0 => self.dispatch_in_state_0(next_state, reader),
+            1 => self.dispatch_in_state_1(next_state, reader),
+            _ => unreachable_panic!("Unreachable state reached in lexer."),
+        }
+    }
+    fn state_0_to_0<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => StageStatus::ContinueWith(1.into()),
+            97 => StageStatus::ContinueWith(2.into()),
+            98 => StageStatus::ContinueWith(3.into()),
+            99..=4294967294 => StageStatus::ContinueWith(1.into()),
+            _ => StageStatus::ContinueWith(4.into()),
+        }
+    }
+    fn state_0_to_1<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_3(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_0_to_2<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            97 => StageStatus::ContinueWith(5.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_0_to_3<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=97 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            98 => StageStatus::ContinueWith(6.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_0_to_4<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_2(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_0_to_5<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            97 => StageStatus::ContinueWith(5.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_0_to_6<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=97 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            98 => StageStatus::ContinueWith(6.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_0_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn dispatch_in_state_0<R: LazyReader>(
+        &mut self,
+        new_state_index: SubStateId,
+        reader: &mut R,
+    ) -> StageStatus {
+        match new_state_index.into() {
+            0 => self.state_0_to_0(reader),
+            1 => self.state_0_to_1(reader),
+            2 => self.state_0_to_2(reader),
+            3 => self.state_0_to_3(reader),
+            4 => self.state_0_to_4(reader),
+            5 => self.state_0_to_5(reader),
+            6 => self.state_0_to_6(reader),
+            _ => unreachable_panic!("Unreachable state reached in lexer."),
+        }
+    }
+    fn group_0_rule_0<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_first_word(reader)
+    }
+    fn group_0_rule_1<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_first_word(reader)
+    }
+    fn group_0_rule_2<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_no_err_suffix_first_word(reader)
+    }
+    fn group_0_rule_3<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_err_suffix_first_word(reader)
+    }
+    fn state_1_to_0<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=31 => StageStatus::ContinueWith(1.into()),
+            32 => StageStatus::ContinueWith(2.into()),
+            33..=4294967294 => StageStatus::ContinueWith(1.into()),
+            _ => StageStatus::ContinueWith(3.into()),
+        }
+    }
+    fn state_1_to_1<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_3(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_2<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_3(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            97 => StageStatus::ContinueWith(4.into()),
+            98 => StageStatus::ContinueWith(5.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_3(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_3<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_2(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_4<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            97 => StageStatus::ContinueWith(6.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_5<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=97 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            98 => StageStatus::ContinueWith(7.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_6<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=96 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            97 => StageStatus::ContinueWith(6.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_0(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn state_1_to_7<R: LazyReader>(&mut self, reader: &mut R) -> StageStatus {
+        match u32::from(reader.character()) {
+            0..=97 => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+            98 => StageStatus::ContinueWith(7.into()),
+            _ => {
+                let matched_bookmark = self.bookmarks.matched_bookmark;
+                self.current_match = reader.pop_result();
+                self.group_1_rule_1(reader);
+                self.bookmarks.bookmark(matched_bookmark, reader);
+                StageStatus::ExitSuccess
+            }
+        }
+    }
+    fn dispatch_in_state_1<R: LazyReader>(
+        &mut self,
+        new_state_index: SubStateId,
+        reader: &mut R,
+    ) -> StageStatus {
+        match new_state_index.into() {
+            0 => self.state_1_to_0(reader),
+            1 => self.state_1_to_1(reader),
+            2 => self.state_1_to_2(reader),
+            3 => self.state_1_to_3(reader),
+            4 => self.state_1_to_4(reader),
+            5 => self.state_1_to_5(reader),
+            6 => self.state_1_to_6(reader),
+            7 => self.state_1_to_7(reader),
+            _ => unreachable_panic!("Unreachable state reached in lexer."),
+        }
+    }
+    fn group_1_rule_0<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_spaced_word(reader)
+    }
+    fn group_1_rule_1<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_spaced_word(reader)
+    }
+    fn group_1_rule_2<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_no_err_suffix(reader)
+    }
+    fn group_1_rule_3<R: LazyReader>(&mut self, reader: &mut R) {
+        self.on_err_suffix(reader)
+    }
+}

--- a/src/flexer-testing/generation/src/generated/engine.rs
+++ b/src/flexer-testing/generation/src/generated/engine.rs
@@ -1,0 +1,283 @@
+#![deny(unconditional_recursion)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+//! This file contains the code defining a lexer for the following small language. Due to the way in
+//! which the code-generation from the flexer is used, it has to be defined in a separate crate from
+//! the site at which it's used. For the actual tests of this code, please see
+//! `flexer-testing/generation`.
+//!
+//! The language here is being defined as follows:
+//!
+//! a-word      = 'a'+;
+//! b-word      = 'b'+;
+//! word        = a-word | b-word;
+//! space       = ' ';
+//! spaced-word = space, word;
+//! language    = word, spaced-word*;
+//!
+//! Please note that there is a fair amount of duplicated code between this test and the
+//! `lexer_generated_api_test` file. This is to present the full view of what each portion of the
+//! process looks like.
+
+use enso_flexer::*;
+use enso_flexer::prelude::*;
+
+use enso_flexer;
+use enso_flexer::automata::pattern::Pattern;
+use enso_flexer::group::Registry;
+use enso_flexer::prelude::logger::Disabled;
+use enso_flexer::prelude::reader::BookmarkManager;
+
+
+
+// ====================
+// === Type Aliases ===
+// ====================
+
+type Logger = Disabled;
+
+
+
+// ===========
+// === AST ===
+// ===========
+
+/// A very simple AST, sufficient for the simple language being defined.
+#[derive(Clone,Debug,PartialEq)]
+pub enum Token {
+    /// A word from the input, consisting of a sequence of all `a` or all `b`.
+    Word(String),
+    /// A token that the lexer is unable to recognise.
+    Unrecognized(String),
+}
+impl Token {
+    /// Construct a new word token.
+    pub fn word(name:impl Into<String>) -> Token {
+        Token::Word(name.into())
+    }
+
+    /// Construct a new unrecognized token.
+    pub fn unrecognized(name:impl Into<String>) -> Token {
+        Token::Unrecognized(name.into())
+    }
+}
+
+/// A representation of a stream of tokens.
+#[allow(missing_docs)]
+#[derive(Clone,Debug,Default,PartialEq)]
+pub struct TokenStream {
+    tokens:Vec<Token>
+}
+
+impl TokenStream {
+    /// Append the provided token to the token stream.
+    pub fn push(&mut self,token:Token) {
+        self.tokens.push(token);
+    }
+}
+
+
+// === Trait Impls ===
+
+impl From<Vec<Token>> for TokenStream {
+    fn from(tokens: Vec<Token>) -> Self {
+        TokenStream {tokens}
+    }
+}
+
+
+
+// ==================
+// === Test Lexer ===
+// ==================
+
+/// The definition of a test lexer for the above-described language.
+#[derive(Debug)]
+pub struct TestLexer {
+    lexer:Flexer<TestState,TokenStream,Logger>
+}
+
+impl Deref for TestLexer {
+    type Target = Flexer<TestState,TokenStream,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for TestLexer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl TestLexer {
+    /// Creates a new instance of this lexer.
+    pub fn new() -> Self {
+        let logger = Logger::new("TestLexer");
+        let lexer  = Flexer::new(logger);
+        TestLexer{lexer}
+    }
+}
+
+/// Rules for the root state.
+#[allow(dead_code,missing_docs)]
+impl TestLexer {
+    fn on_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(str);
+        self.output.push(ast);
+        let id = self.seen_first_word_state;
+        self.push_state(id);
+    }
+
+    fn on_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let ast = Token::Unrecognized(self.current_match.clone());
+        self.output.push(ast);
+    }
+
+    fn on_no_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {}
+
+    fn rules_in_root(lexer:&mut TestLexer) {
+        let a_word        = Pattern::char('a').many1();
+        let b_word        = Pattern::char('b').many1();
+        let any           = Pattern::any();
+        let end           = Pattern::eof();
+
+        let root_group_id = lexer.initial_state;
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+
+        root_group.create_rule(&a_word,"self.on_first_word(reader)");
+        root_group.create_rule(&b_word,"self.on_first_word(reader)");
+        root_group.create_rule(&end,   "self.on_no_err_suffix_first_word(reader)");
+        root_group.create_rule(&any,   "self.on_err_suffix_first_word(reader)");
+    }
+}
+
+/// Rules for the "seen first word" state.
+#[allow(dead_code,missing_docs)]
+impl TestLexer {
+    fn on_spaced_word<R:LazyReader>(&mut self, _reader:&mut R) {
+        let str = self.current_match.clone();
+        let ast = Token::Word(String::from(str.trim()));
+        self.output.push(ast);
+    }
+
+    fn on_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+        self.on_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn on_no_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+        self.on_no_err_suffix_first_word(reader);
+        self.pop_state();
+    }
+
+    fn rules_in_seen_first_word(lexer:&mut TestLexer) {
+        let a_word        = Pattern::char('a').many1();
+        let b_word        = Pattern::char('b').many1();
+        let space         = Pattern::char(' ');
+        let spaced_a_word = &space >> &a_word;
+        let spaced_b_word = &space >> &b_word;
+        let any           = Pattern::any();
+        let end           = Pattern::eof();
+
+        let seen_first_word_group_id = lexer.seen_first_word_state;
+        let seen_first_word_group    = lexer.groups_mut().group_mut(seen_first_word_group_id);
+
+        seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&end,          "self.on_no_err_suffix(reader)");
+        seen_first_word_group.create_rule(&any,          "self.on_err_suffix(reader)");
+    }
+}
+
+
+// === Trait Impls ===
+
+impl enso_flexer::Definition for TestLexer {
+    fn define() -> Self {
+        let mut lexer = TestLexer::new();
+
+        TestLexer::rules_in_seen_first_word(&mut lexer);
+        TestLexer::rules_in_root(&mut lexer);
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {}
+
+    fn tear_down(&mut self) {}
+}
+
+impl Default for TestLexer {
+    fn default() -> Self {
+        TestLexer::new()
+    }
+}
+
+
+
+// ===================
+// === Lexer State ===
+// ===================
+
+/// The stateful components of the test lexer.
+#[derive(Debug)]
+pub struct TestState {
+    /// The registry for groups in the lexer.
+    lexer_states:group::Registry,
+    /// The initial state of the lexer.
+    initial_state:group::Identifier,
+    /// The state entered when the first word has been seen.
+    seen_first_word_state:group::Identifier,
+    /// The bookmarks for this lexer.
+    bookmarks:BookmarkManager
+}
+
+
+// === Trait Impls ===
+
+impl enso_flexer::State for TestState {
+    fn new(_logger:&impl AnyLogger) -> Self {
+        let mut lexer_states      = group::Registry::default();
+        let initial_state         = lexer_states.define_group("ROOT",None);
+        let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+        let bookmarks             = BookmarkManager::new();
+        Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+    }
+
+    fn initial_state(&self) -> group::Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &group::Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut group::Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        &self.bookmarks
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        &mut self.bookmarks
+    }
+
+    fn specialize(&self) -> Result<String,GenError> {
+        generate::specialize(self,"TestLexer","TokenStream")
+    }
+}
+# [allow (missing_docs , dead_code , clippy :: all)] impl TestLexer { pub fn run < R : LazyReader > (& mut self , mut reader : R) -> LexingResult < TokenStream > { self . set_up () ; reader . advance_char (& mut self . bookmarks) ; while self . run_current_state (& mut reader) == StageStatus :: ExitSuccess { } let result = match self . status { StageStatus :: ExitFinished => LexingResult :: success (mem :: take (& mut self . output)) , StageStatus :: ExitFail => LexingResult :: failure (mem :: take (& mut self . output)) , _ => LexingResult :: partial (mem :: take (& mut self . output)) } ; self . tear_down () ; result } fn run_current_state < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { self . status = StageStatus :: Initial ; let mut finished = false ; while let Some (next_state) = self . status . continue_as () { self . logger . debug (| | format ! ("Current character is {:?}." , reader . character () . char)) ; self . logger . debug (| | format ! ("Continuing in {:?}." , next_state)) ; self . status = self . step (next_state , reader) ; if finished && reader . finished (self . bookmarks ()) { self . logger . info ("Input finished.") ; self . status = StageStatus :: ExitFinished } finished = reader . character () . is_eof () ; if self . status . should_continue () { match reader . character () . char { Ok (char) => { reader . append_result (char) ; self . logger . info (| | format ! ("Result is {:?}." , reader . result ())) ; } , Err (enso_flexer :: prelude :: reader :: Error :: EOF) => { self . logger . info ("Reached EOF.") ; } , Err (enso_flexer :: prelude :: reader :: Error :: EndOfGroup) => { let current_state = self . current_state () ; let group_name = self . groups () . group (current_state) . name . as_str () ; let err = format ! ("Missing rules for state {}." , group_name) ; self . logger . error (err . as_str ()) ; panic ! (err) } Err (_) => { self . logger . error ("Unexpected error!") ; panic ! ("Unexpected error!") } } reader . advance_char (& mut self . bookmarks) ; } } self . status } fn step < R : LazyReader > (& mut self , next_state : SubStateId , reader : & mut R) -> StageStatus { let current_state : usize = self . current_state () . into () ; match current_state { 0 => self . dispatch_in_state_0 (next_state , reader) , 1 => self . dispatch_in_state_1 (next_state , reader) , _ => unreachable_panic ! ("Unreachable state reached in lexer.") , } } fn state_0_to_0 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { StageStatus :: ContinueWith (1 . into ()) } , 97 => { StageStatus :: ContinueWith (2 . into ()) } , 98 => { StageStatus :: ContinueWith (3 . into ()) } , 99 ..= 18446744073709551614 => { StageStatus :: ContinueWith (1 . into ()) } , _ => { StageStatus :: ContinueWith (4 . into ()) } , } } fn state_0_to_1 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_3 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_0_to_2 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 97 => { StageStatus :: ContinueWith (5 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_0_to_3 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 97 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 98 => { StageStatus :: ContinueWith (6 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_0_to_4 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_2 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_0_to_5 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 97 => { StageStatus :: ContinueWith (5 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_0_to_6 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 97 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 98 => { StageStatus :: ContinueWith (6 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_0_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn dispatch_in_state_0 < R : LazyReader > (& mut self , new_state_index : SubStateId , reader : & mut R) -> StageStatus { match new_state_index . into () { 0 => self . state_0_to_0 (reader) , 1 => self . state_0_to_1 (reader) , 2 => self . state_0_to_2 (reader) , 3 => self . state_0_to_3 (reader) , 4 => self . state_0_to_4 (reader) , 5 => self . state_0_to_5 (reader) , 6 => self . state_0_to_6 (reader) , _ => unreachable_panic ! ("Unreachable state reached in lexer.") } } fn group_0_rule_0 < R : LazyReader > (& mut self , reader : & mut R) { self . on_first_word (reader) } fn group_0_rule_1 < R : LazyReader > (& mut self , reader : & mut R) { self . on_first_word (reader) } fn group_0_rule_2 < R : LazyReader > (& mut self , reader : & mut R) { self . on_no_err_suffix_first_word (reader) } fn group_0_rule_3 < R : LazyReader > (& mut self , reader : & mut R) { self . on_err_suffix_first_word (reader) } fn state_1_to_0 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 31 => { StageStatus :: ContinueWith (1 . into ()) } , 32 => { StageStatus :: ContinueWith (2 . into ()) } , 33 ..= 18446744073709551614 => { StageStatus :: ContinueWith (1 . into ()) } , _ => { StageStatus :: ContinueWith (3 . into ()) } , } } fn state_1_to_1 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_3 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_2 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_3 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 97 => { StageStatus :: ContinueWith (4 . into ()) } , 98 => { StageStatus :: ContinueWith (5 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_3 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_3 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_2 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_4 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 97 => { StageStatus :: ContinueWith (6 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_5 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 97 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 98 => { StageStatus :: ContinueWith (7 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_6 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 96 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 97 => { StageStatus :: ContinueWith (6 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_0 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn state_1_to_7 < R : LazyReader > (& mut self , reader : & mut R) -> StageStatus { match u64 :: from (reader . character ()) { 0 ..= 97 => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , 98 => { StageStatus :: ContinueWith (7 . into ()) } , _ => { let matched_bookmark = self . bookmarks . matched_bookmark ; self . current_match = reader . pop_result () ; self . group_1_rule_1 (reader) ; self . bookmarks . bookmark (matched_bookmark , reader) ; StageStatus :: ExitSuccess } , } } fn dispatch_in_state_1 < R : LazyReader > (& mut self , new_state_index : SubStateId , reader : & mut R) -> StageStatus { match new_state_index . into () { 0 => self . state_1_to_0 (reader) , 1 => self . state_1_to_1 (reader) , 2 => self . state_1_to_2 (reader) , 3 => self . state_1_to_3 (reader) , 4 => self . state_1_to_4 (reader) , 5 => self . state_1_to_5 (reader) , 6 => self . state_1_to_6 (reader) , 7 => self . state_1_to_7 (reader) , _ => unreachable_panic ! ("Unreachable state reached in lexer.") } } fn group_1_rule_0 < R : LazyReader > (& mut self , reader : & mut R) { self . on_spaced_word (reader) } fn group_1_rule_1 < R : LazyReader > (& mut self , reader : & mut R) { self . on_spaced_word (reader) } fn group_1_rule_2 < R : LazyReader > (& mut self , reader : & mut R) { self . on_no_err_suffix (reader) } fn group_1_rule_3 < R : LazyReader > (& mut self , reader : & mut R) { self . on_err_suffix (reader) } }

--- a/src/flexer-testing/generation/src/lib.rs
+++ b/src/flexer-testing/generation/src/lib.rs
@@ -1,0 +1,19 @@
+//! This library exposes the specialized version of the Enso lexer.
+//!
+//! Its sole purpose is to avoid the lexer definition getting out of sync with its implementation
+//! (the generated engine), which requires the engine to live in a separate crate.
+//!
+//! This separation enables generation of the enso lexer source code with `build.rs` during
+//! compilation. Its output is then stored in a new file `engine.rs`and exported by `lexer.rs`.
+
+#![feature(test)]
+#![deny(unconditional_recursion)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+pub mod generated;

--- a/src/flexer-testing/generation/tests/flexer_generated_lexer.rs
+++ b/src/flexer-testing/generation/tests/flexer_generated_lexer.rs
@@ -1,0 +1,110 @@
+#![feature(test)]
+#![deny(unconditional_recursion)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+//! This file contains tests for the generated lexer.
+
+use enso_flexer::prelude::*;
+
+use enso_flexer::prelude::reader::decoder::DecoderUTF8;
+use flexer_test_generation::generated::engine::TestLexer;
+use flexer_test_generation::generated::engine::Token;
+use flexer_test_generation::generated::engine::TokenStream;
+
+
+
+// =============
+// === Tests ===
+// =============
+
+/// Executes the test on the provided input string slice.
+fn run_test_on(str:impl AsRef<str>) -> TokenStream {
+    // Hardcoded for ease of use here.
+    let reader     = Reader::new(str.as_ref().as_bytes(), DecoderUTF8());
+    let mut lexer  = TestLexer::new();
+    let run_result = lexer.run(reader);
+
+    match run_result.kind {
+        enso_flexer::ResultKind::Success => run_result.tokens,
+        _                                => default()
+    }
+}
+
+#[test]
+fn test_single_a_word() {
+    let input           = "aaaaa";
+    let expected_output = TokenStream::from(vec![Token::word(input)]);
+    let result          = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_single_b_word() {
+    let input           = "bbbbb";
+    let expected_output = TokenStream::from(vec![Token::word(input)]);
+    let result          = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_two_word() {
+    let input           = "aaaaa bbbbb";
+    let expected_output = TokenStream::from(vec![Token::word("aaaaa"), Token::word("bbbbb")]);
+    let result          = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_multi_word() {
+    let input           = "bbb aa a b bbbbb aa";
+    let expected_output = TokenStream::from(vec![
+        Token::word("bbb"),
+        Token::word("aa"),
+        Token::word("a"),
+        Token::word("b"),
+        Token::word("bbbbb"),
+        Token::word("aa")
+    ]);
+    let result = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_invalid_single_word() {
+    let input           = "c";
+    let expected_output = TokenStream::from(vec![Token::unrecognized(input)]);
+    let result          = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_multi_word_invalid() {
+    let input           = "aaaaaa c bbbbbb";
+    let expected_output = TokenStream::from(vec![
+        Token::word("aaaaaa"),
+        Token::unrecognized(" "),
+        Token::unrecognized("c"),
+        Token::unrecognized(" "),
+        Token::word("bbbbbb"),
+    ]);
+    let result = run_test_on(input);
+    assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_end_invalid() {
+    let input           = "bbbbbb c";
+    let expected_output = TokenStream::from(vec![
+        Token::word("bbbbbb"),
+        Token::unrecognized(" "),
+        Token::unrecognized("c"),
+    ]);
+    let result = run_test_on(input);
+    assert_eq!(result, expected_output);
+}

--- a/src/flexer/Cargo.toml
+++ b/src/flexer/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name    = "enso-flexer"
+version = "0.1.0"
+authors = ["Enso Team <enso-dev@enso.org>"]
+edition = "2018"
+
+description  = "A finite-automata-based lexing engine."
+readme       = "README.md"
+homepage     = "https://github.com/enso-org/enso/lib/rust/flexer"
+repository   = "https://github.com/enso-org/enso"
+license-file = "../../../LICENSE"
+
+keywords = ["lexer", "finite-automata"]
+categories = ["parsing"]
+
+publish = false
+
+[lib]
+name       = "enso_flexer"
+crate-type = ["cdylib", "rlib"]
+test       = true
+bench      = true
+
+[dependencies]
+enso-automata    = { version = "0.1.4", path = "../automata"    }
+enso-logger      = { version = "0.1.3", path = "../logger"      }
+enso-prelude     = { version = "0.1.5", path = "../prelude"     }
+enso-lazy-reader = { version = "0.1.1", path = "../lazy-reader" }
+enso-macro-utils = { version = "0.1.1", path = "../macro-utils" }
+
+itertools            = "0.8"
+proc-macro2          = "1.0.19"
+nonempty             = "0.1.5"
+quote                = "1.0"
+syn                  = { version = "1.0.12", features = ["full", "extra-traits", "visit-mut", "visit", "parsing", "printing"] }
+unicode-segmentation = "1.6.0"
+wasm-bindgen         = "0.2"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.2"

--- a/src/flexer/Cargo.toml
+++ b/src/flexer/Cargo.toml
@@ -8,12 +8,12 @@ description  = "A finite-automata-based lexing engine."
 readme       = "README.md"
 homepage     = "https://github.com/enso-org/enso/lib/rust/flexer"
 repository   = "https://github.com/enso-org/enso"
-license-file = "../../../LICENSE"
+license-file = "../../LICENSE"
 
 keywords = ["lexer", "finite-automata"]
 categories = ["parsing"]
 
-publish = false
+publish = true
 
 [lib]
 name       = "enso_flexer"

--- a/src/flexer/README.md
+++ b/src/flexer/README.md
@@ -1,0 +1,4 @@
+# Flexer
+
+This library provides a finite-automata-based lexing engine that can flexibly
+tokenize an input stream.

--- a/src/flexer/src/generate.rs
+++ b/src/flexer/src/generate.rs
@@ -1,0 +1,556 @@
+//! This file contains utilities for generating rust code from lexer definitions, allowing the
+//! flexer to be specialised for a specific language.
+
+use crate::prelude::*;
+use quote::*;
+use syn::*;
+
+use crate::automata::dfa::Dfa;
+use crate::automata::nfa;
+use crate::automata::dfa;
+use crate::automata::state::State;
+use crate::group::Group;
+use crate::group::AutomatonData;
+use crate::group;
+
+use enso_macro_utils::repr;
+use proc_macro2::Literal;
+use std::hash::BuildHasher;
+use std::result::Result;
+use std::fmt;
+
+use crate as flexer;
+
+
+// =======================
+// === Code Generation ===
+// =======================
+
+/// Generate specialized code for the provided lexer `definition`.
+///
+/// This specialized code is a highly-optimised and tailored lexer that dispatches based on simple
+/// code-point switches, with no dynamic lookup. This means that it is very fast, and very low
+/// overhead.
+pub fn specialize
+( definition       : &impl flexer::State
+, state_type_name  : impl Str
+, output_type_name : impl Str
+) -> Result<String,GenError> {
+    let group_registry = definition.groups();
+    let mut body_items = Vec::new();
+    body_items.push(run_function(output_type_name)?);
+    body_items.push(run_current_state_function());
+    body_items.push(step(group_registry));
+    for group in group_registry.all().iter() {
+        body_items.extend(automaton_for_group(group,group_registry)?)
+    }
+    let result = wrap_in_impl_for(state_type_name,body_items)?;
+    let code   = show_code(&result);
+    Ok(code)
+}
+
+
+// === Whole-Lexer Codegen Utilities ===
+
+/// Wrap the provided implementation items into an `impl` block for the provided `state_name` type.
+pub fn wrap_in_impl_for
+( state_name : impl Into<String>
+, body       : Vec<ImplItem>
+) -> Result<ItemImpl,GenError> {
+    let state_name:Ident  = str_to_ident(state_name.into().as_str())?;
+    let mut tree:ItemImpl = parse_quote! {
+        #[allow(missing_docs,dead_code,clippy::all)]
+        impl #state_name {}
+    };
+    tree.items.extend(body);
+    Ok(tree)
+}
+
+/// Generate the `run` function for the specialized lexer.
+///
+/// This function is what the user of the lexer will call to begin execution.
+pub fn run_function(output_type_name:impl Str) -> Result<ImplItem,GenError> {
+    let output_type_name = str_to_path(output_type_name)?;
+    let tree:ImplItem    = parse_quote! {
+        pub fn run<R:LazyReader>(&mut self, mut reader:R) -> LexingResult<#output_type_name> {
+            self.set_up();
+            reader.advance_char(&mut self.bookmarks);
+            while self.run_current_state(&mut reader) == StageStatus::ExitSuccess {}
+            let result = match self.status {
+                StageStatus::ExitFinished => LexingResult::success(
+                    mem::take(&mut self.output)
+                ),
+                StageStatus::ExitFail => LexingResult::failure(
+                    mem::take(&mut self.output)
+                ),
+                _ => LexingResult::partial(mem::take(&mut self.output))
+            };
+            self.tear_down();
+            result
+        }
+    };
+    Ok(tree)
+}
+
+/// Generate the function responsible for executing the lexer in its current state.
+pub fn run_current_state_function() -> ImplItem {
+    let tree:ImplItem = parse_quote! {
+        fn run_current_state<R:LazyReader>(&mut self, reader:&mut R) -> StageStatus {
+            self.status = StageStatus::Initial;
+            let mut finished = false;
+
+            // Runs until reaching a state that no longer says to continue.
+            while let Some(next_state) = self.status.continue_as() {
+                self.logger.debug(||format!("Current character is {:?}.",reader.character().char));
+                self.logger.debug(||format!("Continuing in {:?}.",next_state));
+                self.status = self.step(next_state,reader);
+
+                if finished && reader.finished(self.bookmarks()) {
+                    self.logger.info("Input finished.");
+                    self.status = StageStatus::ExitFinished
+                }
+                finished = reader.character().is_eof();
+
+                if self.status.should_continue() {
+                    match reader.character().char {
+                        Ok(char) => {
+                            reader.append_result(char);
+                            self.logger.info(||format!("Result is {:?}.",reader.result()));
+                        },
+                        Err(enso_flexer::prelude::reader::Error::EOF) => {
+                            self.logger.info("Reached EOF.");
+                        },
+                        Err(enso_flexer::prelude::reader::Error::EndOfGroup) => {
+                            let current_state = self.current_state();
+                            let group_name    = self.groups().group(current_state).name.as_str();
+                            let err           = format!("Missing rules for state {}.", group_name);
+                            self.logger.error(err.as_str());
+                            panic!(err)
+                        }
+                        Err(_) => {
+                            self.logger.error("Unexpected error!");
+                            panic!("Unexpected error!")
+                        }
+                    }
+                    reader.advance_char(&mut self.bookmarks);
+                }
+            }
+
+            self.status
+        }
+    };
+    tree
+}
+
+/// Generate the `step` function for the lexer.
+///
+/// This function is responsible for dispatching based on the current state, consuming a character,
+/// and returning the state to transition to.
+pub fn step(groups:&group::Registry) -> ImplItem {
+    let arms = groups.all().iter().map(|g| step_match_arm(g.id.into())).collect_vec();
+    parse_quote! {
+        fn step<R:LazyReader>(&mut self, next_state:SubStateId, reader:&mut R) -> StageStatus {
+            let current_state:usize = self.current_state().into();
+            match current_state {
+                #(#arms)*
+                _ => unreachable_panic!("Unreachable state reached in lexer."),
+            }
+        }
+    }
+}
+
+/// Generate a match arm for the step function.
+///
+/// There is one match arm per lexer state.
+pub fn step_match_arm(number:usize) -> Arm {
+    let literal           = Literal::usize_unsuffixed(number);
+    let function_name_str = format!("dispatch_in_state_{}",number);
+    let func_name:Ident   = parse_str(function_name_str.as_str()).unwrap();
+    let arm:Arm = parse_quote! {
+        #literal => self.#func_name(next_state,reader),
+    };
+    arm
+}
+
+
+// === Generation for a Specific Lexer State ===
+
+/// Generate the functions that implement the lexer automaton for a given lexer state.
+pub fn automaton_for_group
+( group    : &Group
+, registry : &group::Registry
+) -> Result<Vec<ImplItem>,GenError> {
+    let mut nfa       = registry.to_nfa_from(group.id);
+    let mut rules = Vec::with_capacity(nfa.states().len());
+    for state in nfa.public_states().iter() {
+        if nfa.name(*state).is_some() {
+            rules.push(rule_for_state(state,&nfa)?);
+        }
+    }
+    let mut dfa             = Dfa::from(nfa.automaton());
+    let dispatch_for_dfa    = dispatch_in_state(&dfa,group.id.into())?;
+    let mut dfa_transitions = transitions_for_dfa(&mut dfa,&mut nfa,group.id.into())?;
+    dfa_transitions.push(dispatch_for_dfa);
+    dfa_transitions.extend(rules);
+    Ok(dfa_transitions)
+}
+
+/// Generate a set of transition functions for the provided `dfa`, with identifier `id`.
+pub fn transitions_for_dfa
+( dfa  : &mut Dfa
+, data : &mut AutomatonData
+, id   : usize
+) -> Result<Vec<ImplItem>,GenError> {
+    let mut state_has_overlapping_rules:HashMap<usize,bool> = HashMap::new();
+    state_has_overlapping_rules.insert(0,false);
+    let state_names:Vec<_> = dfa.links.row_indices().map(|ix| (ix,name_for_step(id,ix))).collect();
+    let mut transitions    = Vec::with_capacity(state_names.len());
+    for (ix,name) in state_names.into_iter() {
+        transitions.push(transition_for_dfa(dfa,name,data,ix,&mut state_has_overlapping_rules)?)
+    }
+    Ok(transitions)
+}
+
+/// Generate a specific transition function for
+#[allow(clippy::implicit_hasher)]
+pub fn transition_for_dfa<S:BuildHasher>
+( dfa             : &mut Dfa
+, transition_name : Ident
+, data            : &mut AutomatonData
+, state_ix        : usize
+, has_overlaps    : &mut HashMap<usize,bool,S>
+) -> Result<ImplItem,GenError> {
+    let match_expr:Expr   = match_for_transition(dfa,state_ix,data,has_overlaps)?;
+    let function:ImplItem = parse_quote! {
+        fn #transition_name<R:LazyReader>(&mut self, reader:&mut R) -> StageStatus {
+            #match_expr
+        }
+    };
+    Ok(function)
+}
+
+/// Generate the pattern match for a given transition function.
+pub fn match_for_transition<S:BuildHasher>
+( dfa          : &mut Dfa
+, state_ix     : usize
+, data         : &mut AutomatonData
+, has_overlaps : &mut HashMap<usize,bool,S>
+) -> Result<Expr,GenError> {
+    let overlaps          = *has_overlaps.get(&state_ix).unwrap_or(&false);
+    let mut trigger_state = dfa.links[(state_ix,0)];
+    let mut range_start   = enso_automata::symbol::SymbolIndex::min_value();
+    let divisions         = dfa.alphabet.division_map.clone();
+    let mut branches      = Vec::with_capacity(divisions.len());
+    for (sym, ix) in divisions.into_iter() {
+        let new_trigger_state = dfa.links[(state_ix,ix)];
+        if new_trigger_state != trigger_state {
+            let range_end             = if sym.index != 0 { sym.index - 1 } else { sym.index };
+            let current_trigger_state = trigger_state;
+            let current_range_start   = range_start;
+            trigger_state             = new_trigger_state;
+            range_start               = sym.index;
+            let body =
+                branch_body(dfa,current_trigger_state,state_ix,data,has_overlaps,overlaps)?;
+            branches.push(Branch::new(Some(current_range_start..=range_end),body));
+        } else {}
+    }
+    let catch_all_branch_body = branch_body(dfa,trigger_state,state_ix,data,has_overlaps,overlaps)?;
+    let catch_all_branch      = Branch::new(None,catch_all_branch_body);
+    branches.push(catch_all_branch);
+    let arms:Vec<Arm> = branches.into_iter().map(Into::into).collect();
+    let mut match_expr:ExprMatch = parse_quote! {
+        match u64::from(reader.character()) {
+            #(#arms)*
+        }
+    };
+    match_expr.arms = arms;
+    Ok(Expr::Match(match_expr))
+}
+
+/// Generate the branch body for a transition in the DFA.
+pub fn branch_body<S:BuildHasher>
+( dfa           : &mut Dfa
+, target_state  : State<Dfa>
+, state_ix      : usize
+, data          : &mut AutomatonData
+, has_overlaps  : &mut HashMap<usize,bool,S>
+, rules_overlap : bool
+) -> Result<Block,GenError> {
+    let sources             = dfa.sources.get(state_ix).expect("Internal error.");
+    let rule_name_for_state = data.name_for_dfa_state(sources);
+    if target_state == State::<Dfa>::INVALID {
+        match rule_name_for_state {
+            None => {
+                Ok(parse_quote! {{
+                    StageStatus::ExitFail
+                }})
+            },
+            Some(rule) => {
+                let rule:Expr = match parse_str(rule) {
+                    Ok(rule) => rule,
+                    Err(_) => return Err(GenError::BadExpression(rule.to_string()))
+                };
+                if rules_overlap {
+                    Ok(parse_quote! {{
+                        let rule_bookmark    = self.bookmarks.rule_bookmark;
+                        let matched_bookmark = self.bookmarks.matched_bookmark;
+                        self.bookmarks.rewind(rule_bookmark,reader);
+                        self.current_match = reader.pop_result();
+                        self.#rule(reader);
+                        self.bookmarks.bookmark(matched_bookmark,reader);
+                        StageStatus::ExitSuccess
+                    }})
+                } else {
+                    Ok(parse_quote! {{
+                        let matched_bookmark = self.bookmarks.matched_bookmark;
+                        self.current_match   = reader.pop_result();
+                        self.#rule(reader);
+                        self.bookmarks.bookmark(matched_bookmark,reader);
+                        StageStatus::ExitSuccess
+                    }})
+                }
+            }
+        }
+    } else {
+        let target_state_has_no_rule = match rule_name_for_state {
+            Some(_) => if !dfa_has_rule_name_for(&data, dfa, target_state) {
+                dfa.sources[target_state.id()] = (*sources).clone();
+                has_overlaps.insert(target_state.id(),true);
+                true
+            } else {
+                false
+            },
+            None => false
+        };
+
+        let state_id = Literal::usize_unsuffixed(target_state.id());
+        let ret:Expr = parse_quote! {
+            StageStatus::ContinueWith(#state_id.into())
+        };
+
+        if target_state_has_no_rule && !rules_overlap {
+            Ok(parse_quote! {{
+                let rule_bookmark = self.bookmarks.rule_bookmark;
+                self.bookmarks.bookmark(rule_bookmark,reader);
+                #ret
+            }})
+        } else {
+            Ok(parse_quote! {{
+                #ret
+            }})
+        }
+    }
+}
+
+/// Generate the dispatch function for a given lexer state.
+///
+/// This dispatch function is responsible for dispatching based on the sub-state of any given lexer
+/// state, and is the main part of implementing the actual lexer transitions.
+pub fn dispatch_in_state(dfa:&Dfa, id:usize) -> Result<ImplItem,GenError> {
+    let dispatch_name:Ident = str_to_ident(format!("dispatch_in_state_{}",id))?;
+    let state_names  = dfa.links.row_indices().map(|ix| (ix, name_for_step(id,ix))).collect_vec();
+    let mut branches = Vec::with_capacity(state_names.len());
+    for (ix,name) in state_names.into_iter() {
+        let literal = Literal::usize_unsuffixed(ix);
+        let arm:Arm = parse_quote! {
+            #literal => self.#name(reader),
+        };
+        branches.push(arm);
+    }
+
+    let pattern_match:ExprMatch = parse_quote! {
+        match new_state_index.into() {
+            #(#branches)*
+            _ => unreachable_panic!("Unreachable state reached in lexer.")
+        }
+    };
+    let func:ImplItem = parse_quote! {
+        fn #dispatch_name<R:LazyReader>
+        ( &mut self
+        , new_state_index:SubStateId
+        , reader:&mut R
+        ) -> StageStatus {
+            #pattern_match
+        }
+    };
+
+    Ok(func)
+}
+
+/// Generate a name for a given step function.
+pub fn name_for_step(in_state:usize, to_state:usize) -> Ident {
+    let name_str = format!("state_{}_to_{}",in_state,to_state);
+    parse_str(name_str.as_str()).expect("Impossible to not be a valid identifier.")
+}
+
+/// Generate an executable rule function for a given lexer state.
+pub fn rule_for_state(state:&nfa::State, automaton:&AutomatonData) -> Result<ImplItem,GenError> {
+    let state_name = automaton.name(*state);
+    match state_name {
+        None => unreachable_panic!("Rule for state requested, but state has none."),
+        Some(name) => {
+            let rule_name = str_to_ident(name)?;
+            let callback  = automaton.code(*state).expect("If it is named it has a callback.");
+            let code:Expr = match parse_str(callback) {
+                Ok(expr) => expr,
+                Err(_)   => return Err(GenError::BadExpression(callback.into()))
+            };
+            if !has_reader_arg(&code) {
+                return Err(GenError::BadCallbackArgument)
+            }
+            let tree:ImplItem = parse_quote! {
+                fn #rule_name<R:LazyReader>(&mut self, reader:&mut R) {
+                    #code
+                }
+            };
+            Ok(tree)
+        }
+    }
+}
+
+/// Checks if the given `expr` is a  call with a single argument "reader" being passed.
+#[allow(clippy::cmp_owned)]
+pub fn has_reader_arg(expr:&Expr) -> bool {
+    match expr {
+        Expr::MethodCall(expr) => match expr.args.last() {
+            Some(Expr::Path(path)) => {
+                match path.path.segments.first() {
+                    Some(segment) => {
+                        segment.ident.to_string() == "reader"
+                    }
+                    _ => false
+                }
+            }
+            _ => false
+        },
+        Expr::Call(expr) => match expr.args.last() {
+            Some(Expr::Path(path)) => {
+                match path.path.segments.first() {
+                    Some(segment) => {
+                        segment.ident.to_string() == "reader"
+                    }
+                    _ => false
+                }
+            }
+            _ => false
+        }
+        _ => false
+    }
+}
+
+
+
+// ================
+// === GenError ===
+// ================
+
+/// Errors that arise during code generation.
+#[derive(Clone,Debug,PartialEq)]
+pub enum GenError {
+    /// The callback function does not take a single argument `reader`.
+    BadCallbackArgument,
+    /// The provided string is not a valid rust identifier.
+    BadIdentifier(String),
+    /// The provided expression isn't a valid rust expression.
+    BadExpression(String),
+    /// The provided string is not a valid rust literal.
+    BadLiteral(String),
+    /// The provided string is not a valid rust path.
+    BadPath(String),
+}
+
+
+// === Trait Impls ===
+
+impl Display for GenError {
+    fn fmt(&self, f:&mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GenError::BadCallbackArgument => write!(f,
+                "Bad argument to a callback function. It must take a single argument `reader`."
+            ),
+            GenError::BadIdentifier(str) => write!(f,"`{}` is not a valid rust identifier.",str),
+            GenError::BadExpression(str) => write!(f,"`{}` is not a valid rust expression.",str),
+            GenError::BadLiteral(str)    => write!(f,"`{}` is not a valid rust literal.",str),
+            GenError::BadPath(str)       => write!(f,"`{}` is not a valid rust path.",str),
+        }
+    }
+}
+
+
+
+// ==============
+// === Branch ===
+// ==============
+
+/// A representation of a dispatch branch for helping to generate pattern arms.
+#[allow(missing_docs)]
+#[derive(Clone,Debug,PartialEq)]
+struct Branch {
+    pub range : Option<RangeInclusive<enso_automata::symbol::SymbolIndex>>,
+    pub body  : Block
+}
+
+impl Branch {
+    /// Create a new branch, from the provided `range` and with `body` as the code it executes.
+    pub fn new
+    ( range : Option<RangeInclusive<enso_automata::symbol::SymbolIndex>>
+    , body  : Block
+    ) -> Branch {
+        Branch {range,body}
+    }
+}
+
+
+// === Trait Impls ===
+
+impl Into<Arm> for Branch {
+    fn into(self) -> Arm {
+        let body = self.body;
+        match self.range {
+            Some(range) => {
+                let range_start = Literal::u64_unsuffixed(*range.start());
+                let range_end   = Literal::u64_unsuffixed(*range.end());
+                if range.start() == range.end() {
+                    parse_quote! {
+                        #range_start => #body,
+                    }
+                } else {
+                    parse_quote! {
+                        #range_start..=#range_end => #body,
+                    }
+                }
+            }
+            None => parse_quote! {
+                _ => #body,
+            }
+        }
+    }
+}
+
+
+
+// =================
+// === Utilities ===
+// =================
+
+/// Check if the DFA has a rule name for the provided target `state`.
+pub fn dfa_has_rule_name_for(nfa:&AutomatonData, dfa:&Dfa, state:dfa::State) -> bool {
+    nfa.name_for_dfa_state(&dfa.sources[state.id()]).is_some()
+}
+
+/// Convert a string to an identifier.
+pub fn str_to_ident(str:impl Str) -> Result<Ident,GenError> {
+    parse_str(str.as_ref()).map_err(|_| GenError::BadIdentifier(str.into()))
+}
+
+/// Convert a string to a path.
+pub fn str_to_path(str:impl Str) -> Result<Path,GenError> {
+    parse_str(str.as_ref()).map_err(|_| GenError::BadPath(str.into()))
+}
+
+/// Convert the syntax tree into a string.
+pub fn show_code(tokens:&impl ToTokens) -> String {
+    repr(tokens)
+}
+
+

--- a/src/flexer/src/group.rs
+++ b/src/flexer/src/group.rs
@@ -1,0 +1,453 @@
+//! This module provides an API for grouping multiple flexer rules.
+
+use crate::prelude::*;
+
+use crate::automata::nfa::Nfa;
+use crate::automata::{nfa, state};
+use crate::automata::pattern::Pattern;
+use crate::group::rule::Rule;
+
+use itertools::Itertools;
+use std::fmt::Display;
+use crate::prelude::fmt::Formatter;
+use crate::prelude::HashMap;
+
+pub mod rule;
+
+
+
+// ================
+// === Registry ===
+// ================
+
+/// The group Registry is a container for [`Group`]s in the flexer implementation.
+///
+/// It allows groups to contain associations between themselves, and also implements useful
+/// conversions for groups.
+#[derive(Clone,Debug,Default)]
+pub struct Registry {
+    /// The groups defined for the lexer.
+    groups:Vec<Group>,
+}
+
+impl Registry {
+    /// Defines a new group of rules for the lexer with the specified `name` and `parent`.
+    ///
+    /// It returns the identifier of the newly-created group.
+    pub fn define_group
+    ( &mut self
+    , name         : impl Into<String>
+    , parent_index : Option<Identifier>
+    ) -> Identifier {
+        let id    = self.next_id();
+        let group = Group::new(id,name.into(),parent_index);
+        self.groups.push(group);
+        id
+    }
+
+    /// Adds an existing `group` to the registry, updating and returning its identifier.
+    pub fn add_group(&mut self, mut group:Group) -> Identifier {
+        let new_id = self.next_id();
+        group.id   = new_id;
+        self.groups.push(group);
+        new_id
+    }
+
+    /// Creates a rule that matches `pattern` for the group identified by `group_id`.
+    ///
+    /// Panics if `group_id` refers to a nonexistent group.
+    pub fn create_rule(&mut self, group:Identifier, pattern:&Pattern, callback:impl AsRef<str>) {
+        let group = self.group_mut(group);
+        group.create_rule(pattern,callback.as_ref());
+    }
+
+    /// Associates the provided `rule` with the group identified by `group_id`.
+    ///
+    /// Panics if `group_id` refers to a nonexistent group.
+    pub fn add_rule(&mut self, group:Identifier, rule:Rule) {
+        let group = self.group_mut(group);
+        group.add_rule(rule);
+    }
+
+    /// Collates the entire set of rules that are matchable when the lexer has the group identified
+    /// by `group_id` as active.
+    ///
+    /// This set of rules includes the rules inherited from any parent groups.
+    pub fn rules_for(&self, group:Identifier) -> Vec<&Rule> {
+        let group_handle = self.group(group);
+        let mut parent   = group_handle.parent_index.map(|p| self.group(p));
+        let mut rules    = (&group_handle.rules).iter().collect_vec();
+        while let Some(parent_group) = parent {
+            if parent_group.id == group_handle.id {
+                panic!("There should not be cycles in parent links for lexer groups.")
+            }
+            rules.extend((&parent_group.rules).iter());
+            parent = parent_group.parent_index.map(|p| self.group(p));
+        }
+        rules
+    }
+
+    /// Obtains a reference to the group for the given `group_id`.
+    ///
+    /// As group identifiers can only be created by use of this `Registry`, this will always
+    /// succeed.
+    pub fn group(&self, group:Identifier) -> &Group {
+        self.groups.get(group.0).expect("The group must exist.")
+    }
+
+    /// Obtains a mutable reference to the group for the given `group_id`.
+    ///
+    /// As group identifiers can only be created by use of this `Registry`, this will always
+    /// succeed.
+    pub fn group_mut(&mut self, group:Identifier) -> &mut Group {
+        self.groups.get_mut(group.0).expect("The group should exist.")
+    }
+
+    /// Converts the group identified by `group_id` into an NFA.
+    ///
+    /// Returns `None` if the group does not exist, or if the conversion fails.
+    pub fn to_nfa_from(&self, group_id:Identifier) -> AutomatonData {
+        let group     = self.group(group_id);
+        let mut nfa   = AutomatonData::default();
+        let start     = nfa.automaton.start;
+        nfa.add_public_state(start);
+        let build     = |rule:&Rule| nfa.new_pattern(start,&rule.pattern);
+        let rules     = self.rules_for(group.id);
+        let callbacks = rules.iter().map(|r| r.callback.clone()).collect_vec();
+        let states    = rules.into_iter().map(build).collect_vec();
+        let end       = nfa.new_state_exported();
+        for (ix,state) in states.into_iter().enumerate() {
+            nfa.add_public_state(state);
+            nfa.set_name(state,group.callback_name(ix));
+            nfa.set_code(state,callbacks.get(ix).unwrap().clone());
+            nfa.connect(state,end);
+        }
+        nfa.add_public_state(end);
+        nfa
+    }
+
+    /// Generates the next group identifier for this registry.
+    fn next_id(&self) -> Identifier {
+        let val = self.groups.len();
+        Identifier(val)
+    }
+
+    /// Get an immutable reference to the groups contained within the registry.
+    pub fn all(&self) -> &Vec<Group> {
+        &self.groups
+    }
+}
+
+
+// ====================
+// === AutomataData ===
+// ====================
+
+/// Storage for the generated automaton and auxiliary data required for code generation.
+#[derive(Clone,Debug,Default,PartialEq,Eq)]
+pub struct AutomatonData {
+    /// The non-deterministic finite automaton implementing the group of rules it was generated
+    /// from.
+    automaton : Nfa,
+    /// The states defined in the automaton.
+    states : Vec<nfa::State>,
+    /// The names of callbacks, where provided.
+    transition_names : HashMap<nfa::State,String>,
+    /// The code to execute on a callback, where available.
+    callback_code : HashMap<nfa::State,String>,
+}
+
+impl AutomatonData {
+    /// Set the name for the provided `state_id`.
+    pub fn set_name(&mut self, state_id:nfa::State,name:impl Str) {
+        self.transition_names.insert(state_id,name.into());
+    }
+
+    /// Set the callback code for the provided `state_id`.
+    pub fn set_code(&mut self, state_id:nfa::State,code:impl Str) {
+        self.callback_code.insert(state_id,code.into());
+    }
+
+    /// Add the provided `state` to the state registry.
+    pub fn add_public_state(&mut self, state:nfa::State) {
+        self.states.push(state);
+    }
+
+    /// Get the name for the provided `state_id`, if present.
+    pub fn name(&self, state_id:nfa::State) -> Option<&str> {
+        self.transition_names.get(&state_id).map(|s| s.as_str())
+    }
+
+    /// Get the callback code for the provided `state_id`, if present.
+    pub fn code(&self, state_id:nfa::State) -> Option<&str> {
+        self.callback_code.get(&state_id).map(|s| s.as_str())
+    }
+
+    /// Get a reference to the public states for this automaton.
+    ///
+    /// A public state is one that was explicitly defined by the user.
+    pub fn public_states(&self) -> &Vec<nfa::State> {
+        &self.states
+    }
+
+    /// Get a reference to the states for this automaton.
+    pub fn states(&self) -> &Vec<state::Data> {
+        &self.automaton.states()
+    }
+
+    /// Get a reference to the state names for this automaton.
+    pub fn names(&self) -> &HashMap<nfa::State,String> {
+        &self.transition_names
+    }
+
+    /// Get a reference to the callbacks for this automaton.
+    pub fn callbacks(&self) -> &HashMap<nfa::State,String> {
+        &self.callback_code
+    }
+
+    /// Get a reference to the automaton itself.
+    pub fn automaton(&self) -> &Nfa {
+        &self.automaton
+    }
+
+    /// Get the rule name for a the provided state.
+    pub fn name_for_dfa_state(&self, sources:&Vec<nfa::State>) -> Option<&str> {
+        let mut result = None;
+        for source in sources.iter() {
+            let name = self.name(*source);
+            if name.is_some() {
+                result = name;
+                break;
+            }
+        }
+        result
+    }
+}
+
+/// Errors that can occur when querying callbacks for a DFA state.
+#[derive(Copy,Clone,Debug,Display,Eq,PartialEq)]
+pub enum CallbackError {
+    /// There are no available callbacks for this state.
+    NoCallback,
+    /// There is more than one callback available for this state.
+    DuplicateCallbacks,
+}
+
+
+// === Trait Impls ===
+
+impl Deref for AutomatonData {
+    type Target = Nfa;
+
+    fn deref(&self) -> &Self::Target {
+        &self.automaton
+    }
+}
+
+impl DerefMut for AutomatonData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.automaton
+    }
+}
+
+
+
+// ==================
+// === Identifier ===
+// ==================
+
+/// An identifier for a group.
+#[allow(missing_docs)]
+#[derive(Copy,Clone,Debug,Default,Eq,PartialEq)]
+pub struct Identifier(usize);
+
+
+// === Trait Impls ===
+
+impl From<usize> for Identifier {
+    fn from(id:usize) -> Self {
+        Identifier(id)
+    }
+}
+
+impl From<&usize> for Identifier {
+    fn from(id:&usize) -> Self {
+        Identifier(*id)
+    }
+}
+
+impl Into<usize> for Identifier {
+    fn into(self) -> usize {
+        self.0
+    }
+}
+
+
+
+// ===========
+// == Group ==
+// ===========
+
+/// A group is a structure for associating multiple rules with each other, and is the basic building
+/// block of the flexer.
+///
+/// A group consists of the following:
+///
+/// - A set of [`Rule`s](Rule), each containing a regex pattern and associated callback.
+/// - Inherited rules from a parent group, if such a group exists.
+///
+/// Internally, the flexer maintains a stack of groups, where only one group can be active at any
+/// given time. Rules are matched _in order_, and hence overlaps are handled by the order in which
+/// the rules are matched, with the first callback being triggered.
+///
+/// Whenever a [`rule.pattern`](Rule::pattern) from the active group is matched against part of the
+/// input, the associated [`rule.callback`](Rule::callback) is executed. This callback may exit the
+/// current group or even enter a new one. As a result, groups allow us to elegantly model a
+/// situation where certain parts of a program (e.g. within a string literal) have very different
+/// lexing rules than other portions of a program (e.g. the body of a function).
+#[derive(Clone,Debug,Default)]
+pub struct Group {
+    /// A unique identifier for the group.
+    pub id:Identifier,
+    /// A name for the group (useful in debugging).
+    pub name:String,
+    /// The parent group from which rules are inherited.
+    ///
+    /// It is ensured that the group is held mutably.
+    pub parent_index:Option<Identifier>,
+    /// A set of flexer rules.
+    pub rules:Vec<Rule>,
+    /// The names for the user-defined states.
+    pub state_names:HashMap<usize,String>,
+    /// The callback functions for the user-defined states.
+    pub state_callbacks:HashMap<usize,String>,
+}
+
+impl Group {
+
+    /// Creates a new group.
+    pub fn new(id:Identifier, name:impl Into<String>, parent_index:Option<Identifier>) -> Self {
+        let rules           = default();
+        let state_names     = default();
+        let state_callbacks = default();
+        Group{id,name:name.into(),parent_index,rules,state_names,state_callbacks}
+    }
+
+    /// Adds a new rule to the current group.
+    pub fn add_rule(&mut self, rule:Rule) {
+        self.rules.push(rule)
+    }
+
+    /// Creates a new rule.
+    pub fn create_rule(&mut self, pattern:&Pattern, code:&str) {
+        let pattern_clone = pattern.clone();
+        let rule          = Rule::new(pattern_clone,code);
+        self.rules.push(rule)
+    }
+
+    /// The canonical name for a given rule.
+    pub fn callback_name(&self, rule_ix:usize) -> String {
+        format!("group_{}_rule_{}",self.id.0,rule_ix)
+    }
+}
+
+// === Trait Impls ===
+
+impl Into<Registry> for Group {
+    fn into(self) -> Registry {
+        let mut registry = Registry::default();
+        registry.add_group(self);
+        registry
+    }
+}
+
+impl Display for Group {
+    fn fmt(&self, f:&mut Formatter<'_>) -> std::fmt::Result {
+        write!(f,"Group {}",self.name)
+    }
+}
+
+
+
+// =============
+// === Tests ===
+// =============
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn group_create_rule() {
+        let pattern   = Pattern::all_of("abcde");
+        let mut group = Group::new(0.into(),"Test Name",None);
+        group.create_rule(&pattern,"code");
+        let rule = Rule::new(pattern,"code");
+        assert!(group.rules.contains(&rule));
+        assert_eq!(group.rules[0].callback,"code".to_string());
+    }
+
+    #[test]
+    fn group_callback_name() {
+        let pattern_1 = Pattern::all_of("abcde");
+        let pattern_2 = Pattern::all_of("abcde");
+        let mut group = Group::new(0.into(),"Test Name",None);
+        group.create_rule(&pattern_1,"code");
+        group.create_rule(&pattern_2,"code");
+        assert_eq!(group.callback_name(0),"group_0_rule_0");
+        assert_eq!(group.callback_name(1),"group_0_rule_1");
+    }
+
+    #[test]
+    fn group_registry_define_group() {
+        let mut registry = Registry::default();
+        registry.define_group("TEST_GROUP",None);
+        assert!(registry.all().iter().find(|g| g.name == "TEST_GROUP".to_string()).is_some());
+    }
+
+    #[test]
+    fn group_registry_create_rule() {
+        let pattern      = Pattern::none_of("abcde");
+        let mut registry = Registry::default();
+        let group_1_id   = registry.define_group("GROUP_1",None);
+        let group_2_id   = registry.define_group("GROUP_2",None);
+
+        let group_1      = registry.group_mut(group_1_id);
+        group_1.create_rule(&pattern,"rule_1");
+
+        let group_2  = registry.group_mut(group_2_id);
+        group_2.create_rule(&pattern,"rule_2");
+
+        let rules_1 = registry.rules_for(group_1_id);
+        let rules_2 = registry.rules_for(group_2_id);
+        assert!(rules_1.iter().find(|r| ***r == Rule::new(pattern.clone(),"rule_1")).is_some());
+        assert!(rules_2.iter().find(|r| ***r == Rule::new(pattern.clone(),"rule_2")).is_some());
+    }
+
+    #[test]
+    fn group_registry_group_parents() {
+        let pattern_1 = Pattern::char('a');
+        let pattern_2 = Pattern::char('b');
+        let pattern_3 = Pattern::char('c');
+
+        let mut registry = Registry::default();
+        let group_1_id = registry.define_group("GROUP_1", None);
+        let group_2_id = registry.define_group("GROUP_2", Some(group_1_id));
+        let group_3_id = registry.define_group("GROUP_3", Some(group_2_id));
+
+        let group_1 = registry.group_mut(group_1_id);
+        group_1.create_rule(&pattern_1, "rule_1");
+
+        let group_2 = registry.group_mut(group_2_id);
+        group_2.create_rule(&pattern_2, "rule_2");
+
+        let group_3 = registry.group_mut(group_3_id);
+        group_3.create_rule(&pattern_3, "rule_3");
+
+        let rules = registry.rules_for(group_3_id);
+        assert_eq!(rules.len(), 3);
+        assert!(rules.iter().find(|r| ***r == Rule::new(pattern_1.clone(),"rule_1")).is_some());
+        assert!(rules.iter().find(|r| ***r == Rule::new(pattern_2.clone(),"rule_2")).is_some());
+        assert!(rules.iter().find(|r| ***r == Rule::new(pattern_3.clone(),"rule_3")).is_some());
+    }
+}

--- a/src/flexer/src/group/rule.rs
+++ b/src/flexer/src/group/rule.rs
@@ -1,0 +1,34 @@
+//! An API for declaring rust-code callbacks to be executed when a given pattern is matched.
+//!
+//! A flexer rule is a [`crate::automata::pattern`] associated with rust code to be executed as a
+//! callback.
+
+use crate::automata::pattern::Pattern;
+
+
+
+// ==========
+// == Rule ==
+// ==========
+
+/// A flexer rule.
+#[derive(Clone,Debug,PartialEq)]
+pub struct Rule {
+    /// The pattern that triggers the callback.
+    pub pattern:Pattern,
+
+    /// The code to execute when [`Rule::pattern`] matches, containing rust code as a
+    /// [`std::string::String`].
+    ///
+    /// This code will be called directly from a method defined on your Lexer (the one that contains
+    /// a [`crate::Flexer`] instance. To this end, the code you provide as a string must be valid in
+    /// that context.
+    pub callback:String,
+}
+
+impl Rule {
+    /// Creates a new rule.
+    pub fn new(pattern:Pattern, callback:impl Into<String>) -> Self {
+        Rule{pattern,callback:callback.into()}
+    }
+}

--- a/src/flexer/src/lib.rs
+++ b/src/flexer/src/lib.rs
@@ -1,0 +1,1387 @@
+#![deny(unconditional_recursion)]
+#![feature(test)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unsafe_code)]
+#![warn(unused_import_braces)]
+
+//! This module exports the API for defining a simple lexer based on a deterministic finite state
+//! automaton.
+//!
+//! Lexers defined using the Flexer are capable of lexing languages of significant complexity, and
+//! while they're defined in a simple way (akin to regular grammars), they can work even with
+//! context-sensitive languages.
+//!
+//! The process of defining a lexer involves the user doing the following:
+//!
+//! 1.  Creating a `Lexer` type that wraps the [`Flexer`].
+//! 2.  Creating a `State` type, to hold the user-defined lexing state.
+//! 3.  Implementing [`State`] for the `State` type.
+//! 4.  Implementing [`Definition`] for the `Lexer`, along with lexing transition rules to lex the
+//!     language.
+//!
+//! The result of defining a lexer using the flexer is a hybrid of the code written using this
+//! library, and also the code that this library generates to specialize your lexer.
+//!
+//! # Writing a Lexer
+//!
+//! As the Flexer is a library for writing lexers, it would be remiss of us not to include a worked
+//! example for how to define a lexer. The following example defines a lexer for a small language,
+//! and shows you how to integrate the flexer code generation step with your project's build.
+//!
+//! ## The Language
+//!
+//! We're going to define a lexer for a very simple language, represented by the following
+//! [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form) grammar.
+//!
+//! ```plain
+//! a-word      = 'a'+;
+//! b-word      = 'b'+;
+//! word        = a-word | b-word;
+//! space       = ' ';
+//! spaced-word = space, word;
+//! language    = word, spaced-word*;
+//! ```
+//!
+//! ## The Lexer's Output
+//!
+//! Every lexer needs the ability to write a stream of tokens as its output. A flexer-based lexer
+//! can use any type that it wants as its output type, but this language is going to use a very
+//! simple `Token` type, wrapped into a `TokenStream`.
+//!
+//! ```
+//! #[derive(Clone)]
+//! pub enum Token {
+//!     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//!     Word(String),
+//!     /// A token that the lexer is unable to recognise.
+//!     Unrecognized(String)
+//! }
+//!
+//! #[derive(Clone,Default)]
+//! pub struct TokenStream {
+//!     tokens:Vec<Token>
+//! }
+//!
+//! impl TokenStream {
+//!     pub fn push(&mut self,token:Token) {
+//!         self.tokens.push(token)
+//!     }
+//! }
+//! ```
+//!
+//! These tokens will be inserted into the token stream by our lexer as it recognises valid portions
+//! of our language.
+//!
+//! Whatever you choose as the `Output` type of your lexer, it will need to implement both
+//! [`std::clone::Clone`] and [`std::default::Default`].
+//!
+//! ## The Lexer's State
+//!
+//! Every Flexer-based lexer operates over a state that holds all of the user-defined state
+//! information required to define the particular lexer. This state type must conform to the
+//! [`State`] trait, which defines important functionality that it must provide to the flexer.
+//!
+//! In our language, we want to only be able to match words with a preceding space character once
+//! we've seen an initial word that doesn't have one. To this end, we need a state in our lexer to
+//! record that we've 'seen' the first word. As required by the [`State`] trait, we also need to
+//! provide the flexer with an initial state, the state registry, and the bookmarks we use.
+//!
+//! ```
+//! use enso_flexer::group;
+//! use enso_flexer::prelude::reader::BookmarkManager;
+//! use enso_flexer::State;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//!
+//!
+//! // === LexerState ===
+//!
+//! #[derive(Debug)]
+//! pub struct LexerState {
+//!     /// The registry for groups in the lexer.
+//!     lexer_states:group::Registry,
+//!     /// The initial state of the lexer.
+//!     initial_state:group::Identifier,
+//!     /// The state entered when the first word has been seen.
+//!     seen_first_word_state:group::Identifier,
+//!     /// The bookmarks for this lexer.
+//!     bookmarks:BookmarkManager
+//! }
+//! ```
+//!
+//! The flexer library provides useful functionality to help with defining your lexer state, such as
+//! [`group::Registry`] for containing the various states through which your lexer may transition,
+//! amd [`prelude::reader::BookmarkManager`] for storing bookmarks.
+//!
+//! > ### Bookmarks
+//! > In order to enable arbitrary lookahead, the flexer provides a system for "bookmarking" a point
+//! > in the input stream so that the lexer may return to it later. In fact, this mechanism is used
+//! > _by default_ in the implementation to deal with overlapping rules, and so the
+//! > [`prelude::reader::BookmarkManager`] provides some bookmarks for you by default.
+//! >
+//! > As a user, however, you can define additional bookmarks as part of your state, and mark or
+//! > return to them as part of your lexer's transition functions (more on this below).
+//!
+//! Now that we have our state type, we need to define an implementation of [`State`] for it. This
+//! is a mostly trivial exercise, but two functions ([`State::new()`] and [`State::specialize`])
+//! require special attention. We'll look at both below.
+//!
+//! ```
+//! use enso_flexer::generate;
+//! # use enso_flexer::group;
+//! use enso_flexer::generate::GenError;
+//! use enso_flexer::prelude::AnyLogger;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//!
+//! impl enso_flexer::State for LexerState {
+//!     fn new(_logger:&impl AnyLogger) -> Self {
+//!         // Here we construct all of the elements needed for our lexer state. This function can
+//!         // contain arbitrarily complex logic and is only called once at initialization time.
+//!         let mut lexer_states      = group::Registry::default();
+//!         let initial_state         = lexer_states.define_group("ROOT",None);
+//!         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//!         let bookmarks             = BookmarkManager::new();
+//!         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//!     }
+//!
+//!     fn initial_state(&self) -> group::Identifier {
+//!         self.initial_state
+//!     }
+//!
+//!     fn groups(&self) -> &group::Registry {
+//!         &self.lexer_states
+//!     }
+//!
+//!     fn groups_mut(&mut self) -> &mut group::Registry {
+//!         &mut self.lexer_states
+//!     }
+//!
+//!     fn bookmarks(&self) -> &BookmarkManager {
+//!         &self.bookmarks
+//!     }
+//!
+//!     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//!         &mut self.bookmarks
+//!     }
+//!
+//!     fn specialize(&self) -> Result<String,GenError> {
+//!         // It is very important to pass both the type name of your lexer and your output
+//!         // correctly here. This function should always be implemented as a call to the
+//!         // below-used function.
+//!         generate::specialize(self,"TestLexer","Token")
+//!     }
+//! }
+//! ```
+//!
+//! ## Defining the Lexer Type
+//!
+//! With our state type defined, we now have the prerequisites for defining the lexer itself!
+//!
+//! The notion behind the way we define lexers in the flexer is to use a chain of
+//! [`std::ops::Deref`] implementations to make the disparate parts feel like a cohesive whole.
+//! The [`Flexer`] itself already implements deref to your state type, so all that remains is to do
+//! the following:
+//!
+//! 1.  Define your lexer struct itself, containing an instance of the [`Flexer`], parametrised by
+//!     your state and output types.
+//!
+//! ```
+//! use enso_flexer::Flexer;
+//! # use enso_flexer::generate;
+//! # use enso_flexer::group;
+//! # use enso_flexer::prelude::GenError;
+//! # use enso_flexer::prelude::AnyLogger;
+//! use enso_flexer::prelude::logger::Disabled;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//!
+//! type Logger = Disabled;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//! #
+//! # impl enso_flexer::State for LexerState {
+//! #     fn new(_logger:&impl AnyLogger) -> Self {
+//! #         // Here we construct all of the elements needed for our lexer state. This function can
+//! #         // contain arbitrarily complex logic and is only called once at initialization time.
+//! #         let mut lexer_states      = group::Registry::default();
+//! #         let initial_state         = lexer_states.define_group("ROOT",None);
+//! #         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//! #         let bookmarks             = BookmarkManager::new();
+//! #         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//! #     }
+//! #
+//! #     fn initial_state(&self) -> group::Identifier {
+//! #         self.initial_state
+//! #     }
+//! #
+//! #     fn groups(&self) -> &group::Registry {
+//! #         &self.lexer_states
+//! #     }
+//! #
+//! #     fn groups_mut(&mut self) -> &mut group::Registry {
+//! #         &mut self.lexer_states
+//! #     }
+//! #
+//! #     fn bookmarks(&self) -> &BookmarkManager {
+//! #         &self.bookmarks
+//! #     }
+//! #
+//! #     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//! #         &mut self.bookmarks
+//! #     }
+//! #
+//! #     fn specialize(&self) -> Result<String,GenError> {
+//! #         // It is very important to pass both the type name of your lexer and your output
+//! #         // correctly here. This function should always be implemented as a call to the
+//! #         // below-used function.
+//! #         generate::specialize(self,"TestLexer","Token")
+//! #     }
+//! # }
+//!
+//!
+//! // === Lexer ===
+//!
+//! pub struct Lexer {
+//!    lexer:Flexer<LexerState,TokenStream,Logger>
+//! }
+//! ```
+//!
+//! You'll note that the `Flexer` also takes a logging implementation from the Enso logging library
+//! as a type parameter. This lets the client of the library configure the behaviour of logging in
+//! their lexer. We recommend aliasing the current logger type (as shown above) for ease of use.
+//!
+//! 2.  Implement a `new()` function for your lexer.
+//!
+//! ```
+//! # use enso_flexer::Flexer;
+//! # use enso_flexer::generate;
+//! # use enso_flexer::group;
+//! # use enso_flexer::prelude::AnyLogger;
+//! # use enso_flexer::prelude::GenError;
+//! # use enso_flexer::prelude::logger::Disabled;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//! #
+//! # type Logger = Disabled;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//! #
+//! # impl enso_flexer::State for LexerState {
+//! #     fn new(_logger:&impl AnyLogger) -> Self {
+//! #         // Here we construct all of the elements needed for our lexer state. This function can
+//! #         // contain arbitrarily complex logic and is only called once at initialization time.
+//! #         let mut lexer_states      = group::Registry::default();
+//! #         let initial_state         = lexer_states.define_group("ROOT",None);
+//! #         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//! #         let bookmarks             = BookmarkManager::new();
+//! #         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//! #     }
+//! #
+//! #     fn initial_state(&self) -> group::Identifier {
+//! #         self.initial_state
+//! #     }
+//! #
+//! #     fn groups(&self) -> &group::Registry {
+//! #         &self.lexer_states
+//! #     }
+//! #
+//! #     fn groups_mut(&mut self) -> &mut group::Registry {
+//! #         &mut self.lexer_states
+//! #     }
+//! #
+//! #     fn bookmarks(&self) -> &BookmarkManager {
+//! #         &self.bookmarks
+//! #     }
+//! #
+//! #     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//! #         &mut self.bookmarks
+//! #     }
+//! #
+//! #     fn specialize(&self) -> Result<String,GenError> {
+//! #         // It is very important to pass both the type name of your lexer and your output
+//! #         // correctly here. This function should always be implemented as a call to the
+//! #         // below-used function.
+//! #         generate::specialize(self,"TestLexer","Token")
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === Lexer ===
+//! #
+//! # pub struct Lexer {
+//! #    lexer:Flexer<LexerState,TokenStream,Logger>
+//! # }
+//!
+//! impl Lexer {
+//!     pub fn new() -> Self {
+//!         let lexer = Flexer::new(Logger::new("Lexer"));
+//!         Lexer{lexer}
+//!     }
+//! }
+//! ```
+//!
+//! 3.  Define [`std::ops::Deref`] and [`std::ops::DerefMut`] for your lexer.
+//!
+//! ```
+//! # use enso_flexer::Flexer;
+//! # use enso_flexer::generate;
+//! # use enso_flexer::group;
+//! # use enso_flexer::prelude::AnyLogger;
+//! # use enso_flexer::prelude::GenError;
+//! # use enso_flexer::prelude::logger::Disabled;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//! use std::ops::Deref;
+//! use std::ops::DerefMut;
+//! #
+//! # type Logger = Disabled;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//! #
+//! # impl enso_flexer::State for LexerState {
+//! #     fn new(_logger:&impl AnyLogger) -> Self {
+//! #         // Here we construct all of the elements needed for our lexer state. This function can
+//! #         // contain arbitrarily complex logic and is only called once at initialization time.
+//! #         let mut lexer_states      = group::Registry::default();
+//! #         let initial_state         = lexer_states.define_group("ROOT",None);
+//! #         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//! #         let bookmarks             = BookmarkManager::new();
+//! #         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//! #     }
+//! #
+//! #     fn initial_state(&self) -> group::Identifier {
+//! #         self.initial_state
+//! #     }
+//! #
+//! #     fn groups(&self) -> &group::Registry {
+//! #         &self.lexer_states
+//! #     }
+//! #
+//! #     fn groups_mut(&mut self) -> &mut group::Registry {
+//! #         &mut self.lexer_states
+//! #     }
+//! #
+//! #     fn bookmarks(&self) -> &BookmarkManager {
+//! #         &self.bookmarks
+//! #     }
+//! #
+//! #     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//! #         &mut self.bookmarks
+//! #     }
+//! #
+//! #     fn specialize(&self) -> Result<String,GenError> {
+//! #         // It is very important to pass both the type name of your lexer and your output
+//! #         // correctly here. This function should always be implemented as a call to the
+//! #         // below-used function.
+//! #         generate::specialize(self,"TestLexer","Token")
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === Lexer ===
+//! #
+//! # pub struct Lexer {
+//! #    lexer:Flexer<LexerState,TokenStream,Logger>
+//! # }
+//! #
+//! # impl Lexer {
+//! #     pub fn new() -> Self {
+//! #         let lexer = Flexer::new(Logger::new("Lexer"));
+//! #         Lexer{lexer}
+//! #     }
+//! # }
+//!
+//! impl Deref for Lexer {
+//!     type Target = Flexer<LexerState,TokenStream,Logger> ;
+//!     fn deref(&self) -> &Self::Target {
+//!         &self.lexer
+//!     }
+//! }
+//! impl DerefMut for Lexer {
+//!     fn deref_mut(&mut self) -> &mut Self::Target {
+//!         &mut self.lexer
+//!     }
+//! }
+//! ```
+//!
+//! You'll note that here we've instantiated the flexer with a `Logger`. This is used for providing
+//! debug information during development, and can be accessed from all scopes of your lexer. In
+//! release mode, however, logging calls at the "trace", "debug", and "info" levels are optimised
+//! away.
+//!
+//! ## Defining the Lexing Rules
+//!
+//! Flexer-based lexers operate by matching on a series of [`automata::pattern::Pattern`]s that
+//! describe the language that it is trying to lex. It combines these patterns with "transition
+//! functions" that may execute arbitrary code when a pattern matches on the lexer's input.
+//!
+//! In order to define the lexing rules, we need to implement [`Definition`] for our lexer,
+//! particularly the [`Definition::define()`] function.
+//!
+//! ```
+//! use enso_flexer::automata::pattern::Pattern;
+//! # use enso_flexer::Flexer;
+//! # use enso_flexer::generate;
+//! use enso_flexer::group::Registry;
+//! # use enso_flexer::group;
+//! # use enso_flexer::prelude::AnyLogger;
+//! # use enso_flexer::prelude::GenError;
+//! # use enso_flexer::prelude::logger::Disabled;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//! use enso_flexer;
+//! # use std::ops::Deref;
+//! # use std::ops::DerefMut;
+//! #
+//! # type Logger = Disabled;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//! #
+//! # impl enso_flexer::State for LexerState {
+//! #     fn new(_logger:&impl AnyLogger) -> Self {
+//! #         // Here we construct all of the elements needed for our lexer state. This function can
+//! #         // contain arbitrarily complex logic and is only called once at initialization time.
+//! #         let mut lexer_states      = group::Registry::default();
+//! #         let initial_state         = lexer_states.define_group("ROOT",None);
+//! #         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//! #         let bookmarks             = BookmarkManager::new();
+//! #         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//! #     }
+//! #
+//! #     fn initial_state(&self) -> group::Identifier {
+//! #         self.initial_state
+//! #     }
+//! #
+//! #     fn groups(&self) -> &group::Registry {
+//! #         &self.lexer_states
+//! #     }
+//! #
+//! #     fn groups_mut(&mut self) -> &mut group::Registry {
+//! #         &mut self.lexer_states
+//! #     }
+//! #
+//! #     fn bookmarks(&self) -> &BookmarkManager {
+//! #         &self.bookmarks
+//! #     }
+//! #
+//! #     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//! #         &mut self.bookmarks
+//! #     }
+//! #
+//! #     fn specialize(&self) -> Result<String,GenError> {
+//! #         // It is very important to pass both the type name of your lexer and your output
+//! #         // correctly here. This function should always be implemented as a call to the
+//! #         // below-used function.
+//! #         generate::specialize(self,"TestLexer","Token")
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === Lexer ===
+//! #
+//! # pub struct Lexer {
+//! #    lexer:Flexer<LexerState,TokenStream,Logger>
+//! # }
+//! #
+//! # impl Lexer {
+//! #     pub fn new() -> Self {
+//! #         let lexer = Flexer::new(Logger::new("Lexer"));
+//! #         Lexer{lexer}
+//! #     }
+//! # }
+//! #
+//! # impl Deref for Lexer {
+//! #     type Target = Flexer<LexerState,TokenStream,Logger> ;
+//! #     fn deref(&self) -> &Self::Target {
+//! #         &self.lexer
+//! #     }
+//! # }
+//! # impl DerefMut for Lexer {
+//! #     fn deref_mut(&mut self) -> &mut Self::Target {
+//! #         &mut self.lexer
+//! #     }
+//! # }
+//!
+//! impl enso_flexer::Definition for Lexer {
+//!     fn define() -> Self {
+//!         // First we instantiate our lexer. Definitions take place _directly_ on the lexer, and
+//!         // manipulate runtime state.
+//!         let mut lexer = Self::new();
+//!
+//!         // Then, we define the patterns that we're going to use. For an overview of the p
+//!         let a_word        = Pattern::char('a').many1();
+//!         let b_word        = Pattern::char('b').many1();
+//!         let space         = Pattern::char(' ');
+//!         let spaced_a_word = &space >> &a_word;
+//!         let spaced_b_word = &space >> &b_word;
+//!         let any           = Pattern::any();
+//!         let end           = Pattern::eof();
+//!
+//!         // Next, we define groups of lexer rules. This uses the groups that we've defined in our
+//!         // lexer's state, and the patterns we've defined above.
+//!         let root_group_id = lexer.initial_state;
+//!         let root_group    = lexer.groups_mut().group_mut(root_group_id);
+//!         root_group.create_rule(&a_word,"self.on_first_word(reader)");
+//!         root_group.create_rule(&b_word,"self.on_first_word(reader)");
+//!         root_group.create_rule(&end,   "self.on_no_err_suffix_first_word(reader)");
+//!         root_group.create_rule(&any,   "self.on_err_suffix_first_word(reader)");
+//!
+//!         let seen_first_word_group_id = lexer.seen_first_word_state;
+//!         let seen_first_word_group    = lexer.groups_mut().group_mut(seen_first_word_group_id);
+//!         seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader)");
+//!         seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader)");
+//!         seen_first_word_group.create_rule(&end,          "self.on_no_err_suffix(reader)");
+//!         seen_first_word_group.create_rule(&any,          "self.on_err_suffix(reader)");
+//!
+//!         lexer
+//!     }
+//!
+//!     /// This function just returns the lexer's groups.
+//!     fn groups(&self) -> &Registry {
+//!         self.lexer.groups()
+//!     }
+//!
+//!     /// Code you want to run before lexing begins.
+//!     fn set_up(&mut self) {}
+//!
+//!     /// Code you want to run after lexing finishes.
+//!     fn tear_down(&mut self) {}
+//! }
+//! ```
+//!
+//! > ### Transition Functions
+//! > You may be wondering why the transition functions are specified as strings. This allows us to
+//! > generate highly-efficient, specialized code for your lexer once you define it. More on this
+//! > later.
+//!
+//! A [`group::Group`] in the lexer is like a state that operates on a stack. A transition function
+//! can arbitrarily activate or deactivate a group on the flexer's stack, allowing you to perform
+//! context-sensitive lexing behaviour. For more information (including on how to use parent groups
+//! to inherit rules), see the relevant module.
+//!
+//! For more information on the [`automata::pattern::Pattern`] APIs used above, please see the
+//! relevant module in this crate.
+//!
+//! ## Defining the Transition Functions
+//!
+//! You'll have noticed that, up above, we told the rules to use a bunch of transition functions
+//! that we've not yet talked about. These functions can be defined anywhere you like, as long as
+//! they are in scope in the file in which you are defining your lexer. We do, however, recommend
+//! defining them on your lexer itself, so they can access and manipulate lexer state, so that's
+//! what we're going to do here.
+//!
+//! ```
+//! # use enso_flexer::automata::pattern::Pattern;
+//! # use enso_flexer::Flexer;
+//! # use enso_flexer::generate;
+//! # use enso_flexer::group::Registry;
+//! # use enso_flexer::group;
+//! # use enso_flexer::prelude::AnyLogger;
+//! use enso_flexer::prelude::LazyReader;
+//! # use enso_flexer::prelude::GenError;
+//! # use enso_flexer::prelude::logger::Disabled;
+//! # use enso_flexer::prelude::reader::BookmarkManager;
+//! # use enso_flexer::State;
+//! # use enso_flexer;
+//! # use std::ops::Deref;
+//! # use std::ops::DerefMut;
+//! #
+//! # type Logger = Disabled;
+//! #
+//! #
+//! # // === Token ===
+//! #
+//! # #[derive(Clone)]
+//! # pub enum Token {
+//! #     /// A word from the input, consisting of a sequence of all `a` or all `b`.
+//! #     Word(String),
+//! #     /// A token that the lexer is unable to recognise.
+//! #     Unrecognized(String)
+//! # }
+//! #
+//! # #[derive(Clone,Default)]
+//! # pub struct TokenStream {
+//! #     tokens:Vec<Token>
+//! # }
+//! #
+//! # impl TokenStream {
+//! #     pub fn push(&mut self,token:Token) {
+//! #         self.tokens.push(token)
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === LexerState ===
+//! #
+//! # #[derive(Debug)]
+//! # pub struct LexerState {
+//! #     /// The registry for groups in the lexer.
+//! #     lexer_states:group::Registry,
+//! #     /// The initial state of the lexer.
+//! #     initial_state:group::Identifier,
+//! #     /// The state entered when the first word has been seen.
+//! #     seen_first_word_state:group::Identifier,
+//! #     /// The bookmarks for this lexer.
+//! #     bookmarks:BookmarkManager
+//! # }
+//! #
+//! # impl enso_flexer::State for LexerState {
+//! #     fn new(_logger:&impl AnyLogger) -> Self {
+//! #         // Here we construct all of the elements needed for our lexer state. This function can
+//! #         // contain arbitrarily complex logic and is only called once at initialization time.
+//! #         let mut lexer_states      = group::Registry::default();
+//! #         let initial_state         = lexer_states.define_group("ROOT",None);
+//! #         let seen_first_word_state = lexer_states.define_group("SEEN FIRST WORD",None);
+//! #         let bookmarks             = BookmarkManager::new();
+//! #         Self{lexer_states,initial_state,seen_first_word_state,bookmarks}
+//! #     }
+//! #
+//! #     fn initial_state(&self) -> group::Identifier {
+//! #         self.initial_state
+//! #     }
+//! #
+//! #     fn groups(&self) -> &group::Registry {
+//! #         &self.lexer_states
+//! #     }
+//! #
+//! #     fn groups_mut(&mut self) -> &mut group::Registry {
+//! #         &mut self.lexer_states
+//! #     }
+//! #
+//! #     fn bookmarks(&self) -> &BookmarkManager {
+//! #         &self.bookmarks
+//! #     }
+//! #
+//! #     fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+//! #         &mut self.bookmarks
+//! #     }
+//! #
+//! #     fn specialize(&self) -> Result<String,GenError> {
+//! #         // It is very important to pass both the type name of your lexer and your output
+//! #         // correctly here. This function should always be implemented as a call to the
+//! #         // below-used function.
+//! #         generate::specialize(self,"TestLexer","Token")
+//! #     }
+//! # }
+//! #
+//! #
+//! # // === Lexer ===
+//! #
+//! # pub struct Lexer {
+//! #    lexer:Flexer<LexerState,TokenStream,Logger>
+//! # }
+//! #
+//! # impl Lexer {
+//! #     pub fn new() -> Self {
+//! #         let lexer = Flexer::new(Logger::new("Lexer"));
+//! #         Lexer{lexer}
+//! #     }
+//! # }
+//! #
+//! # impl Deref for Lexer {
+//! #     type Target = Flexer<LexerState,TokenStream,Logger> ;
+//! #     fn deref(&self) -> &Self::Target {
+//! #         &self.lexer
+//! #     }
+//! # }
+//! # impl DerefMut for Lexer {
+//! #     fn deref_mut(&mut self) -> &mut Self::Target {
+//! #         &mut self.lexer
+//! #     }
+//! # }
+//! #
+//! # impl enso_flexer::Definition for Lexer {
+//! #     fn define() -> Self {
+//! #         // First we instantiate our lexer. Definitions take place _directly_ on the lexer, and
+//! #         // manipulate runtime state.
+//! #         let mut lexer = Self::new();
+//! #
+//! #         // Then, we define the patterns that we're going to use. For an overview of the p
+//! #         let a_word        = Pattern::char('a').many1();
+//! #         let b_word        = Pattern::char('b').many1();
+//! #         let space         = Pattern::char(' ');
+//! #         let spaced_a_word = &space >> &a_word;
+//! #         let spaced_b_word = &space >> &b_word;
+//! #         let any           = Pattern::any();
+//! #         let end           = Pattern::eof();
+//! #
+//! #         // Next, we define groups of lexer rules. This uses the groups that we've defined in our
+//! #         // lexer's state, and the patterns we've defined above.
+//! #         let root_group_id = lexer.initial_state;
+//! #         let root_group    = lexer.groups_mut().group_mut(root_group_id);
+//! #         root_group.create_rule(&a_word,"self.on_first_word(reader)");
+//! #         root_group.create_rule(&b_word,"self.on_first_word(reader)");
+//! #         root_group.create_rule(&end,   "self.on_no_err_suffix_first_word(reader)");
+//! #         root_group.create_rule(&any,   "self.on_err_suffix_first_word(reader)");
+//! #
+//! #         let seen_first_word_group_id = lexer.seen_first_word_state;
+//! #         let seen_first_word_group    = lexer.groups_mut().group_mut(seen_first_word_group_id);
+//! #         seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader)");
+//! #         seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader)");
+//! #         seen_first_word_group.create_rule(&end,          "self.on_no_err_suffix(reader)");
+//! #         seen_first_word_group.create_rule(&any,          "self.on_err_suffix(reader)");
+//! #
+//! #         lexer
+//! #     }
+//! #
+//! #     /// This function just returns the lexer's groups.
+//! #     fn groups(&self) -> &Registry {
+//! #         self.lexer.groups()
+//! #     }
+//! #
+//! #     /// Code you want to run before lexing begins.
+//! #     fn set_up(&mut self) {}
+//! #
+//! #     /// Code you want to run after lexing finishes.
+//! #     fn tear_down(&mut self) {}
+//! # }
+//!
+//! impl Lexer {
+//!      pub fn on_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+//!         let str = self.current_match.clone();
+//!         let ast = Token::Word(str);
+//!         self.output.push(ast);
+//!         let id = self.seen_first_word_state;
+//!         self.push_state(id);
+//!     }
+//!
+//!     pub fn on_spaced_word<R:LazyReader>(&mut self, _reader:&mut R) {
+//!         let str = self.current_match.clone();
+//!         let ast = Token::Word(String::from(str.trim()));
+//!         self.output.push(ast);
+//!     }
+//!
+//!     pub fn on_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {
+//!         let ast = Token::Unrecognized(self.current_match.clone());
+//!         self.output.push(ast);
+//!     }
+//!
+//!     pub fn on_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+//!         self.on_err_suffix_first_word(reader);
+//!         self.pop_state();
+//!     }
+//!
+//!     pub fn on_no_err_suffix_first_word<R:LazyReader>(&mut self, _reader:&mut R) {}
+//!
+//!     pub fn on_no_err_suffix<R:LazyReader>(&mut self, reader:&mut R) {
+//!         self.on_no_err_suffix_first_word(reader);
+//!         self.pop_state();
+//!     }
+//! }
+//! ```
+//!
+//! > ### Magic Transition Functions
+//! > The transition functions are the 'secret sauce', so to speak, of the Flexer. They are called
+//! > when a rule matches, and allow arbitrary code to manipulate the lexer. This means that the
+//! > flexer can be used to define very complex grammars while still keeping a simple interface and
+//! > ensuring performant execution.
+//!
+//! You'll note that all of these functions have a couple of things in common:
+//!
+//! 1.  They have a type parameter `R` that conforms to the [`prelude::LazyReader`] trait.
+//! 2.  They take an argument of type `R`, that is the reader over which the lexer is running as the
+//!     _last_ argument to the function.
+//! 3.  Any additional arguments must be valid in the scope in which the specialisation rules are
+//!     going to be generated.
+//!
+//! Both of these, combined, allow the transition functions to manipulate the text being read by the
+//! lexer.
+//!
+//! ## Specializing the Lexer
+//!
+//! In order to actually _use_ the lexer that you've defined, you need to specialize it to the rules
+//! that you define. Unfortunately, `cargo` doesn't have support for post-build hooks, and so this
+//! is a little more involved than we'd like it to be.
+//!
+//! 1.  Create a file that performs the definition of the lexer as above. It can use multiple files
+//!     in its crate as long as they are publicly exposed.
+//! 2.  Create a separate cargo project that has a prebuild hook in its `build.rs`.
+//! 3.  In that build.rs, you need to:
+//!     1. Import the lexer definition and instantiate it using `::define()`.
+//!     2. Call [`State::specialize()`] on the resultant lexer. This will generate a string that
+//!        contains the optimised lexer implementation.
+//!     3. Write both the generated code and the code from the original lexer definition into an
+//!        output file.
+//! 4.  Re-export this output file from your cargo project's `lib.rs`.
+//!
+//! The process of specialization will generate quite a bit of code, but most importantly it will
+//! generate `pub fn run<R:LazyReader>(&mut self, mut reader:R) -> Result<Output>`, where `Output`
+//! is your lexer's token type. All of these functions are defined on your lexer type (the one whose
+//! name is provided to `specialize()`.
+//!
+//! ## In Summary
+//!
+//! The flexer allows its clients to define highly optimised lexer implementations that are capable
+//! of lexing languages of a high complexity.
+
+use crate::prelude::*;
+use prelude::logger::*;
+
+use crate::generate::GenError;
+use prelude::logger::AnyLogger;
+use prelude::reader::BookmarkManager;
+
+pub use enso_automata as automata;
+pub use enso_automata::c;
+pub use enso_automata::l;
+pub mod generate;
+pub mod group;
+
+/// Useful libraries for working with the flexer.
+pub mod prelude {
+    pub use crate::generate::GenError;
+    pub use enso_prelude::*;
+    pub use lazy_reader::LazyReader;
+    pub use lazy_reader::Reader;
+    pub use logger::AnyLogger;
+
+    /// The lazy reader library.
+    pub mod reader {
+        pub use lazy_reader::*;
+    }
+
+    /// The Enso logging library.
+    pub mod logger {
+        pub use enso_logger::*;
+        pub use enso_logger::disabled::Logger as Disabled;
+        pub use enso_logger::enabled::Logger as Enabled;
+    }
+}
+
+
+
+// =================
+// === Constants ===
+// =================
+
+mod constants {
+    /// The number of 'frames' to reserve in the state stack, aiming to avoid re-allocation in hot
+    /// code paths.
+    pub const STATE_STACK_RESERVATION:usize = 1024;
+}
+
+
+
+// ==============
+// === Flexer ===
+// ==============
+
+/// The flexer is an engine for generating lexers.
+///
+/// Akin to flex and other lexer generators, it is given a definition as a series of rules from
+/// which it then generates code for a highly optimised lexer implemented on top of a
+/// [DFA](https://en.wikipedia.org/wiki/Deterministic_finite_automaton).
+///
+/// Lexers defined using the flexer work on a stack of _states_, where a state is represented by a
+/// [`crate::group::Group`]. Being in a given state (represented below by the top of the
+/// `state_stack`) means that the flexer can match a certain set of rules associated with that
+/// state. The user may cause the lexer to transition between states by pushing and popping states
+/// on the stack, thus allowing a much more flexible lexing engine than pure regular grammars.
+#[derive(Clone,Debug)]
+pub struct Flexer<Definition,Output,Logger> {
+    /// The stack of states that are active during lexer execution.
+    pub state_stack:NonEmptyVec<group::Identifier>,
+    /// The result of the current stage of the DFA.
+    pub status:StageStatus,
+    /// The tokens that have been lexed.
+    pub output:Output,
+    /// The text of the current match of the lexer.
+    pub current_match:String,
+    /// A logger for the flexer, accessible in user definitions.
+    pub logger:Logger,
+    /// The definition of the user-provided state for the lexer.
+    definition:Definition,
+}
+
+impl<Definition,Output,Logger> Flexer<Definition,Output,Logger>
+where Definition : State,
+      Logger     : AnyLogger<Owned=Logger>,
+      Output     : Default {
+    /// Create a new lexer instance.
+    pub fn new(parent_logger:impl AnyLogger) -> Flexer<Definition,Output,Logger> {
+        let logger           = <Logger>::sub(&parent_logger,"Flexer");
+        let status           = default();
+        let output           = default();
+        let definition       = Definition::new(&logger);
+        let initial_state_id = definition.initial_state();
+        let mut state_stack  = NonEmptyVec::singleton(initial_state_id);
+        let current_match    = default();
+
+        state_stack.reserve(constants::STATE_STACK_RESERVATION);
+        Flexer{state_stack,status,output,definition,current_match,logger}
+    }
+}
+
+impl<Definition,Output,Logger> Flexer<Definition,Output,Logger>
+where Definition : State,
+      Output     : Clone,
+      Logger     : AnyLogger<Owned=Logger> {
+    /// Get the lexer result.
+    pub fn result(&mut self) -> &Output {
+        &self.output
+    }
+
+    /// Get the lexer's initial state.
+    pub fn initial_state(&self) -> group::Identifier {
+        self.definition.initial_state()
+    }
+
+    /// Get the state that the lexer is currently in.
+    pub fn current_state(&self) -> group::Identifier {
+        *self.state_stack.last()
+    }
+
+    /// Tell the lexer to enter the state described by `state`.
+    pub fn push_state(&mut self, state:group::Identifier) {
+        self.logger.group_begin(
+            ||format!("Enter State: {}",self.groups().group(state).name.as_str())
+        );
+        self.state_stack.push(state);
+    }
+
+    /// End the current state, returning the popped state identifier if one was ended.
+    ///
+    /// It will never end the initial state of the lexer.
+    pub fn pop_state(&mut self) -> Option<group::Identifier> {
+        let result = self.state_stack.pop();
+        match result {
+            None        => (),
+            Some(ident) => debug!(self.logger,"Leave State: {self.groups().group(ident).name}"),
+        };
+        self.logger.group_end();
+        result
+    }
+
+    /// End states until the specified `state` is reached, leaving the lexer in `state`.
+    ///
+    /// If `state` does not exist on the lexer's stack, then the lexer will be left in the root
+    /// state. Additionally, this function cannot pop the final occurrence of the root state.
+    pub fn pop_states_until(&mut self, state:group::Identifier) -> group::Identifier {
+        while self.current_state() != state && self.current_state() != self.initial_state() {
+            self.pop_state();
+        }
+        *self.state_stack.last()
+    }
+
+    /// End states up to and including the first instance of `state`, returning the identifier of
+    /// the new state the lexer is in.
+    ///
+    /// If `state` does not exist on the lexer's stack, the lexer will be left in the root state.
+    /// Additionally, this function cannot pop the final occurrence of the root state.
+    pub fn pop_states_including(&mut self, state:group::Identifier) -> group::Identifier {
+        while self.current_state() != state && self.current_state() != self.initial_state() {
+            self.pop_state();
+        }
+        self.pop_state();
+        *self.state_stack.last()
+    }
+
+    /// Check if the lexer is currently in the state described by `state`.
+    pub fn is_in_state(&self, state:group::Identifier) -> bool {
+        self.current_state() == state
+    }
+
+    /// Check if the lexer is currently inside `state` at some point in the state stack.
+    pub fn is_inside_state(&self, state:group::Identifier) -> bool {
+        self.state_stack.iter().rev().any(|s| *s == state)
+    }
+}
+
+// === Trait Impls ===
+
+impl<Definition,Output,Logger> Deref for Flexer<Definition,Output,Logger> {
+    type Target = Definition;
+    fn deref(&self) -> &Self::Target {
+        &self.definition
+    }
+}
+
+impl<Definition,Output,Logger> DerefMut for Flexer<Definition,Output,Logger> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.definition
+    }
+}
+
+
+
+// ==================
+// === SubStateId ===
+// ==================
+
+/// An identifier for a sub-state of the lexer to transition to.
+#[derive(Copy,Clone,Debug,Default,PartialEq)]
+pub struct SubStateId(usize);
+
+impl SubStateId {
+    /// Create a new `SubStateId` with the specified value.
+    pub fn new(val:usize) -> SubStateId {
+        SubStateId(val)
+    }
+}
+
+
+// === Trait Impls ===
+
+impl From<usize> for SubStateId {
+    fn from(val:usize) -> Self {
+        SubStateId::new(val)
+    }
+}
+
+impl From<&usize> for SubStateId {
+    fn from(val:&usize) -> Self {
+        SubStateId::new(*val)
+    }
+}
+
+impl Into<usize> for SubStateId {
+    fn into(self) -> usize {
+        self.0
+    }
+}
+
+
+
+// ===================
+// === StageStatus ===
+// ===================
+
+/// The result of executing a single step of the DFA.
+#[derive(Clone,Copy,Debug,PartialEq)]
+pub enum StageStatus {
+    /// The initial state of a lexer stage.
+    Initial,
+    /// The stage exits successfully, having consumed a complete token.
+    ExitSuccess,
+    /// The stage exits unsuccessfully.
+    ExitFail,
+    /// A single step of the DFA has executed successfully.
+    ExitFinished,
+    /// The lexer should continue, transitioning to the included state.
+    ContinueWith(SubStateId)
+}
+
+impl StageStatus {
+    /// Check if the lexer stage should continue.
+    pub fn should_continue(&self) -> bool {
+        self.continue_as().is_some()
+    }
+
+    /// Obtain the state to which the lexer should transition, iff the lexer should continue.
+    pub fn continue_as(&self) -> Option<SubStateId> {
+        match self {
+            StageStatus::Initial           => Some(SubStateId::new(0)),
+            StageStatus::ContinueWith(val) => Some(*val),
+            _                              => None
+        }
+    }
+}
+
+
+// === Trait Impls ===
+
+impl Default for StageStatus {
+    fn default() -> Self {
+        StageStatus::Initial
+    }
+}
+
+
+
+// ==============
+// === Result ===
+// ==============
+
+/// The result of executing the lexer on a given input.
+#[derive(Clone,Debug)]
+pub struct LexingResult<T> {
+    /// The kind of the result, representing _how_ the lexer completed.
+    pub kind:ResultKind,
+    /// The tokens that the lexer was able to process.
+    pub tokens:T
+}
+
+impl<T> LexingResult<T> {
+    /// Create a new lexer result using the provided `kind` and `tokens`.
+    pub fn new(kind:ResultKind,tokens:T) -> LexingResult<T> {
+        LexingResult {kind,tokens}
+    }
+
+    /// Create a new success result, with the provided `tokens`.
+    pub fn success(tokens:T) -> LexingResult<T> {
+        LexingResult::new(ResultKind::Success, tokens)
+    }
+
+    /// Create a new partial lex result, with the provided `tokens`.
+    pub fn partial(tokens:T) -> LexingResult<T> {
+        LexingResult::new(ResultKind::Partial, tokens)
+    }
+
+    /// Create a failure result, with the `tokens` it _did_ manage to consume.
+    pub fn failure(tokens:T) -> LexingResult<T> {
+        LexingResult::new(ResultKind::Failure, tokens)
+    }
+}
+
+/// The kind of lexer result.
+#[derive(Copy,Clone,Debug)]
+pub enum ResultKind {
+    /// The lexer succeeded, returning the contained token stream.
+    Success,
+    /// The lexer succeeded on part of the input, returning the contained token stream.
+    Partial,
+    /// The lexer failed on the input, returning any tokens it _did_ manage to consume.
+    Failure
+}
+
+
+
+// =============
+// === State ===
+// =============
+
+/// Contains the state needed by the flexer from a lexer implementation.
+///
+/// The types for which this trait is implemented will normally also contain the user-defined state
+/// for that lexer.
+pub trait State {
+    /// Create a new instance of the lexer's state.
+    ///
+    /// This function is guaranteed to be called at most once per run of the lexer.
+    fn new(parent_logger:&impl AnyLogger) -> Self;
+    /// Return the _initial_ lexing state.
+    fn initial_state(&self) -> group::Identifier;
+    /// Return a reference to the group registry for a given lexer.
+    fn groups(&self) -> &group::Registry;
+    /// Return a mutable reference to the group registry for a given lexer.
+    fn groups_mut(&mut self) -> &mut group::Registry;
+    /// Get an immutable reference to the bookmark manager for this state.
+    fn bookmarks(&self) -> &BookmarkManager;
+    /// Get a mutable reference to the bookmark manager for this state.
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager;
+    /// Generate code to specialize the flexer for the user's particular lexer definition.
+    ///
+    /// This function should be implemented as a call to [`generate::specialize`], passing
+    /// the name of your lexer, and the name of your lexer's output type as a string.
+    fn specialize(&self) -> Result<String,GenError>;
+}
+
+
+
+// ==================
+// === Definition ===
+// ==================
+
+/// Allows for the definition of flexer-based lexers.
+pub trait Definition {
+    /// Define the custom lexer.
+    fn define() -> Self;
+    /// Obtain the registry of groups for the lexer.
+    fn groups(&self) -> &group::Registry;
+    /// Run before any lexing takes place.
+    fn set_up(&mut self);
+    /// Run after lexing has completed.
+    fn tear_down(&mut self);
+}

--- a/src/flexer/tests/flexer_invalid_definitions.rs
+++ b/src/flexer/tests/flexer_invalid_definitions.rs
@@ -1,0 +1,447 @@
+//! This file contains tests for the user-facing error-handling logic in the flexer code generator.
+//!
+//! This file includes quite a bit of duplicated code, but this is known and intentional as it
+//! allows for increased clarity in the testing.
+
+#![allow(missing_docs)]
+
+use enso_flexer::*;
+
+use crate::prelude::LazyReader;
+use crate::prelude::logger::AnyLogger;
+use crate::prelude::logger::Disabled;
+use crate::prelude::reader::BookmarkManager;
+use enso_flexer::automata::pattern::Pattern;
+use enso_flexer::Flexer;
+use enso_flexer::generate;
+use enso_flexer::group::{Registry, Identifier};
+use enso_flexer::group;
+use enso_flexer::prelude::*;
+use enso_flexer::State;
+use enso_flexer;
+
+
+
+// ====================
+// === Type Aliases ===
+// ====================
+
+type Logger = Disabled;
+
+
+
+// ====================
+// === Shared Setup ===
+// ====================
+
+/// A token type for these lexers.
+#[derive(Copy,Clone,Debug,PartialEq)]
+pub enum Token {
+    Foo,
+    Bar
+}
+
+/// An output type for these lexers.
+#[allow(missing_docs)]
+#[derive(Clone,Debug,Default,PartialEq)]
+pub struct Output {
+    tokens:Vec<Token>
+}
+
+/// A testing lexer state.
+pub struct LexerState {
+    lexer_states:group::Registry,
+    initial_state:group::Identifier,
+}
+impl enso_flexer::State for LexerState {
+    fn new(_logger:&impl AnyLogger) -> Self {
+        let mut lexer_states = group::Registry::default();
+        let initial_state    = lexer_states.define_group("ROOT",None);
+        LexerState{lexer_states,initial_state}
+    }
+
+    fn initial_state(&self) -> Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        unimplemented!()
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        unimplemented!()
+    }
+
+    fn specialize(&self) -> Result<String,GenError> {
+        // Note [Naming "Lexer"]
+        generate::specialize(self,"Lexer","Output")
+    }
+}
+
+/* Note [Naming "Lexer"]
+ * ~~~~~~~~~~~~~~~~~~~~~
+ * In general, the name passed to `specialize` should match that of your lexer definition. However
+ * here, as we never compile the code, we set it to a generic constant that is a valid rust
+ * identifier so as to reduce testing boilerplate.
+ */
+
+
+
+// ====================
+// === Definition 1 ===
+// ====================
+
+pub struct Lexer1 {
+    lexer:Flexer<LexerState,Output,Logger>
+}
+
+impl Deref for Lexer1 {
+    type Target = Flexer<LexerState,Output,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for Lexer1 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl Lexer1 {
+    pub fn new() -> Lexer1 {
+        let logger = Logger::new("Lexer1");
+        let lexer  = Flexer::new(logger);
+        Lexer1 {lexer}
+    }
+
+    pub fn my_test_fun<R:LazyReader>(&mut self, _reader:&mut R) {
+        unimplemented!()
+    }
+}
+
+impl enso_flexer::Definition for Lexer1 {
+    fn define() -> Self {
+        let mut lexer = Self::new();
+
+        let foo = Pattern::all_of("foo");
+
+        let root_group_id = lexer.initial_state();
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+        root_group.create_rule(&foo, "ETERNAL SCREAMING");
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {
+        unimplemented!()
+    }
+
+    fn tear_down(&mut self) {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn test_bad_rule_expression() {
+    let lexer  = Lexer1::define();
+    let result = lexer.specialize();
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert_eq!(message,"`ETERNAL SCREAMING` is not a valid rust expression.");
+}
+
+
+// ====================
+// === Definition 2 ===
+// ====================
+
+pub struct Lexer2 {
+    lexer:Flexer<LexerState,Output,Logger>
+}
+
+impl Deref for Lexer2 {
+    type Target = Flexer<LexerState,Output,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for Lexer2 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl Lexer2 {
+    pub fn new() -> Lexer2 {
+        let logger = Logger::new("Lexer2");
+        let lexer  = Flexer::new(logger);
+        Lexer2{lexer}
+    }
+
+    pub fn my_test_fun<R:LazyReader>(&mut self, _reader:&mut R) {
+        unimplemented!()
+    }
+}
+
+impl enso_flexer::Definition for Lexer2 {
+    fn define() -> Self {
+        let mut lexer = Self::new();
+
+        let foo = Pattern::all_of("foo");
+
+        let root_group_id = lexer.initial_state();
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+        root_group.create_rule(&foo, "self.test_function_no_reader()");
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {
+        unimplemented!()
+    }
+
+    fn tear_down(&mut self) {
+        unimplemented!()
+    }
+}
+
+#[test]
+pub fn test_no_reader_arg() {
+    let lexer            = Lexer2::define();
+    let result           = lexer.specialize();
+    let expected_message =
+        "Bad argument to a callback function. It must take a single argument `reader`.";
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert_eq!(message,expected_message);
+}
+
+
+
+// ====================
+// === Definition 3 ===
+// ====================
+
+pub struct Lexer3 {
+    lexer:Flexer<LexerState1,Output,Logger>
+}
+
+impl Deref for Lexer3 {
+    type Target = Flexer<LexerState1,Output,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for Lexer3 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl Lexer3 {
+    pub fn new() -> Lexer3 {
+        let logger = Logger::new("Lexer3");
+        let lexer  = Flexer::new(logger);
+        Lexer3{lexer}
+    }
+
+    pub fn my_test_fun<R:LazyReader>(&mut self, _reader:&mut R) {
+        unimplemented!()
+    }
+}
+
+impl enso_flexer::Definition for Lexer3 {
+    fn define() -> Self {
+        let mut lexer = Self::new();
+
+        let foo = Pattern::all_of("foo");
+
+        let root_group_id = lexer.initial_state();
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+        root_group.create_rule(&foo, "self.test_function_reader(reader)");
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {
+        unimplemented!()
+    }
+
+    fn tear_down(&mut self) {
+        unimplemented!()
+    }
+}
+
+pub struct LexerState1 {
+    lexer_states:group::Registry,
+    initial_state:group::Identifier,
+}
+impl enso_flexer::State for LexerState1 {
+    fn new(_logger:&impl AnyLogger) -> Self {
+        let mut lexer_states = group::Registry::default();
+        let initial_state    = lexer_states.define_group("ROOT",None);
+        LexerState1 {lexer_states,initial_state}
+    }
+
+    fn initial_state(&self) -> Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        unimplemented!()
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        unimplemented!()
+    }
+
+    fn specialize(&self) -> Result<String,GenError> {
+        generate::specialize(self,"Bad Lexer Name","Output")
+    }
+}
+
+#[test]
+pub fn test_bad_state_name() {
+    let lexer  = Lexer3::define();
+    let result = lexer.specialize();
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert_eq!(message,"`Bad Lexer Name` is not a valid rust identifier.");
+}
+
+
+
+// ====================
+// === Definition 4 ===
+// ====================
+
+pub struct Lexer4 {
+    lexer:Flexer<LexerState2,Output,Logger>
+}
+
+impl Deref for Lexer4 {
+    type Target = Flexer<LexerState2,Output,Logger>;
+    fn deref(&self) -> &Self::Target {
+        &self.lexer
+    }
+}
+
+impl DerefMut for Lexer4 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lexer
+    }
+}
+
+impl Lexer4 {
+    pub fn new() -> Lexer4 {
+        let logger = Logger::new("Lexer4");
+        let lexer  = Flexer::new(logger);
+        Lexer4{lexer}
+    }
+
+    pub fn my_test_fun<R:LazyReader>(&mut self, _reader:&mut R) {
+        unimplemented!()
+    }
+}
+
+impl enso_flexer::Definition for Lexer4 {
+    fn define() -> Self {
+        let mut lexer = Self::new();
+
+        let foo = Pattern::all_of("foo");
+
+        let root_group_id = lexer.initial_state();
+        let root_group    = lexer.groups_mut().group_mut(root_group_id);
+        root_group.create_rule(&foo, "self.test_function_reader(reader)");
+
+        lexer
+    }
+
+    fn groups(&self) -> &Registry {
+        self.lexer.groups()
+    }
+
+    fn set_up(&mut self) {
+        unimplemented!()
+    }
+
+    fn tear_down(&mut self) {
+        unimplemented!()
+    }
+}
+
+pub struct LexerState2 {
+    lexer_states:group::Registry,
+    initial_state:group::Identifier,
+}
+impl enso_flexer::State for LexerState2 {
+    fn new(_logger:&impl AnyLogger) -> Self {
+        let mut lexer_states = group::Registry::default();
+        let initial_state    = lexer_states.define_group("ROOT",None);
+        LexerState2 {lexer_states,initial_state}
+    }
+
+    fn initial_state(&self) -> Identifier {
+        self.initial_state
+    }
+
+    fn groups(&self) -> &Registry {
+        &self.lexer_states
+    }
+
+    fn groups_mut(&mut self) -> &mut Registry {
+        &mut self.lexer_states
+    }
+
+    fn bookmarks(&self) -> &BookmarkManager {
+        unimplemented!()
+    }
+
+    fn bookmarks_mut(&mut self) -> &mut BookmarkManager {
+        unimplemented!()
+    }
+
+    fn specialize(&self) -> Result<String,GenError> {
+        generate::specialize(self,"Lexer4","Bad output name")
+    }
+}
+
+#[test]
+pub fn test_bad_output_name() {
+    let lexer  = Lexer4::define();
+    let result = lexer.specialize();
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert_eq!(message,"`Bad output name` is not a valid rust path.");
+}


### PR DESCRIPTION
### Pull Request Description
This PR extracts the flexer from the engine repository as a general-purpose library for defining lexers.

### Important Notes
No functional changes have taken place, just renames as necessary.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
