### PR TITLE
Make `reader` the First Argument

### DIFF
--- a/src/flexer-testing/definition/src/lib.rs
+++ b/src/flexer-testing/definition/src/lib.rs
@@ -162,7 +162,7 @@ impl TestLexer {
 /// Rules for the "seen first word" state.
 #[allow(dead_code,missing_docs)]
 impl TestLexer {
-    fn on_spaced_word<R:ReaderOps>(&mut self, _reader:&mut R) {
+    fn on_spaced_word<R:ReaderOps>(&mut self, _reader:&mut R, _test_arg:bool) {
         let str = self.current_match.clone();
         let ast = Token::Word(String::from(str.trim()));
         self.output.push(ast);
@@ -190,8 +190,8 @@ impl TestLexer {
         let seen_first_word_group_id = lexer.seen_first_word_state;
         let seen_first_word_group    = lexer.groups_mut().group_mut(seen_first_word_group_id);
 
-        seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader)");
-        seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader)");
+        seen_first_word_group.create_rule(&spaced_a_word,"self.on_spaced_word(reader,true)");
+        seen_first_word_group.create_rule(&spaced_b_word,"self.on_spaced_word(reader,false)");
         seen_first_word_group.create_rule(&end,          "self.on_no_err_suffix(reader)");
         seen_first_word_group.create_rule(&any,          "self.on_err_suffix(reader)");
     }

--- a/src/flexer/Cargo.toml
+++ b/src/flexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-flexer"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/flexer/src/generate.rs
+++ b/src/flexer/src/generate.rs
@@ -412,7 +412,7 @@ pub fn rule_for_state(state:nfa::State, automaton:&AutomatonData) -> Result<Impl
 #[allow(clippy::cmp_owned)]
 pub fn has_reader_arg(expr:&Expr) -> bool {
     match expr {
-        Expr::MethodCall(expr) => match expr.args.last() {
+        Expr::MethodCall(expr) => match expr.args.first() {
             Some(Expr::Path(path)) => {
                 match path.path.segments.first() {
                     Some(segment) => {

--- a/src/flexer/src/lib.rs
+++ b/src/flexer/src/lib.rs
@@ -982,7 +982,7 @@
 //!
 //! 1.  They have a type parameter `R` that conforms to the [`prelude::LazyReader`] trait.
 //! 2.  They take an argument of type `R`, that is the reader over which the lexer is running as the
-//!     _last_ argument to the function.
+//!     _first_ non-`self` argument to the function.
 //! 3.  Any additional arguments must be valid in the scope in which the specialisation rules are
 //!     going to be generated.
 //!


### PR DESCRIPTION
### Pull Request Description
Make `reader` the first argument in the flexer.

### Important Notes
Breaking change!!

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
