### PR TITLE
Adding dependency graph implementation

### DIFF
--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-data"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Enso Team <contact@luna-lang.org>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ publish = true
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-enso-prelude = { version = "0.1.8" , path = "../prelude" }
+enso-prelude = { version = "0.1.10" , path = "../prelude" }
 serde        = { version = "1.0"  , features = ["derive"] }
 typenum = { version = "1.11.2" }
 

--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-data"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Enso Team <contact@luna-lang.org>"]
 edition = "2018"
 

--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-data"
-version = "0.1.5"
+version = "0.1.4"
 authors = ["Enso Team <contact@luna-lang.org>"]
 edition = "2018"
 

--- a/src/data/src/dependency_graph.rs
+++ b/src/data/src/dependency_graph.rs
@@ -11,11 +11,13 @@ use std::collections::BTreeSet;
 // ============
 
 /// A dependency graph node. Registers all incoming and outgoing edges.
-#[derive(Clone,Debug,Default)]
+#[derive(Clone,Debug)]
+#[derive(Derivative)]
+#[derivative(Default(bound=""))]
 #[allow(missing_docs)]
-pub struct Node {
-    pub ins : Vec<usize>,
-    pub out : Vec<usize>,
+pub struct Node<T> {
+    pub ins : Vec<T>,
+    pub out : Vec<T>,
 }
 
 
@@ -33,83 +35,107 @@ pub struct Node {
 /// This decision was dictated by the use cases of this structure. It is used to record dependencies
 /// of display elements, however, in case you remove a display element, its depth-sorting
 /// information should remain intact.
-#[derive(Clone,Debug,Default)]
-pub struct DependencyGraph {
-    nodes : Vec<Node>
+#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Default(bound="T:Eq+Hash+Ord"))]
+#[derivative(Debug(bound="T:Debug+Eq+Hash"))]
+pub struct DependencyGraph<T> {
+    nodes : BTreeMap<T,Node<T>>
 }
 
-impl DependencyGraph {
+impl<T:Clone+Eq+Hash+Ord> DependencyGraph<T> {
     /// Constructor.
     pub fn new() -> Self {
         default()
     }
 
     /// Insert a new dependency to the graph.
-    pub fn insert_dependency(&mut self, first:usize, second:usize) {
-        self.grow(1 + first.max(second));
-        self.nodes[first].out.push(second);
-        self.nodes[second].ins.push(first);
+    pub fn insert_dependency(&mut self, first:T, second:T) {
+        let first_key  = first.clone();
+        let second_key = second.clone();
+        self.nodes.entry(first_key).or_default().out.push(second);
+        self.nodes.entry(second_key).or_default().ins.push(first);
     }
 
     /// Removes all dependencies from nodes whose indexes do not belong to the provided slice.
-    pub fn keep_only(&mut self, ixes:&[usize]) {
-        self.unchecked_keep_only(&ixes.iter().copied().sorted().rev().collect_vec())
+    pub fn keep_only(&mut self, keys:&[T]) {
+        self.unchecked_keep_only(&keys.iter().cloned().sorted().rev().collect_vec())
     }
 
     /// Removes all dependencies from nodes whose indexes do not belong to the provided slice.
-    pub fn kept_only(mut self, ixes:&[usize]) -> Self {
-        self.keep_only(ixes);
+    pub fn kept_only(mut self, keys:&[T]) -> Self {
+        self.keep_only(keys);
         self
     }
 
     /// Just like [`keep_only`], but the provided slice must be sorted in reversed order.
-    pub fn unchecked_keep_only(&mut self, rev_sorted_ixes:&[usize]) {
-        let mut keep         = rev_sorted_ixes.to_vec();
+    pub fn unchecked_keep_only(&mut self, rev_sorted_keys:&[T]) {
+        let mut keep         = rev_sorted_keys.to_vec();
         let mut next_to_keep = keep.pop();
-        for ix in 0..self.nodes.len() {
-            if next_to_keep == Some(ix) {
-                next_to_keep = keep.pop();
-            } else {
-                let node = mem::take(&mut self.nodes[ix]);
-                for ix2 in node.ins { self.nodes[ix2].out.remove(ix); }
-                for ix2 in node.out { self.nodes[ix2].ins.remove(ix); }
+        let     keys         = self.nodes.keys().cloned().collect_vec();
+        let mut keys_iter    = keys.iter();
+        let mut opt_key      = keys_iter.next();
+        loop {
+            match opt_key {
+                None => break,
+                Some(key) => {
+                    match next_to_keep.as_ref().map(|t| t.cmp(&key)) {
+                        Some(std::cmp::Ordering::Less) => {
+                            next_to_keep = keep.pop()
+                        },
+                        Some(std::cmp::Ordering::Equal) => {
+                            next_to_keep = keep.pop();
+                            opt_key      = keys_iter.next();
+                        }
+                        _ => {
+                            if let Some(node) = self.nodes.get_mut(&key) {
+                                let node = mem::take(node);
+                                for key2 in node.ins {
+                                    self.nodes.get_mut(&key2).for_each(|t| t.out.remove_item(&key))
+                                }
+                                for key2 in node.out {
+                                    self.nodes.get_mut(&key2).for_each(|t| t.ins.remove_item(&key))
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
 
     /// Just like [`kept_only`], but the provided slice must be sorted in reversed order.
-    pub fn unchecked_kept_only(mut self, rev_sorted_ixes:&[usize]) -> Self {
-        self.unchecked_keep_only(rev_sorted_ixes);
+    pub fn unchecked_kept_only(mut self, rev_sorted_keys:&[T]) -> Self {
+        self.unchecked_keep_only(rev_sorted_keys);
         self
     }
 
     /// Sorts the provided indexes in topological order based on the rules recorded in the graph.
     /// In case the graph is not a DAG, it will still be sorted by breaking cycles on elements with
     /// the smallest index.
-    pub fn topo_sort(&self, ixes:&[usize]) -> Vec<usize> {
-        self.unchecked_topo_sort(ixes.iter().copied().sorted().rev().collect_vec())
+    pub fn topo_sort(&self, keys:&[T]) -> Vec<T> {
+        self.unchecked_topo_sort(keys.iter().cloned().sorted().rev().collect_vec())
     }
 
     /// Just like [`topo_sort`], but the provided slice must be sorted in reversed order.
-    pub fn unchecked_topo_sort(&self, rev_sorted_ixes:Vec<usize>) -> Vec<usize> {
-        let mut sorted      = Vec::<usize>::new();
-        let mut orphans     = BTreeSet::<usize>::new();
-        let mut non_orphans = BTreeSet::<usize>::new();
-        let mut this        = self.clone().unchecked_kept_only(&rev_sorted_ixes);
-        let max_elem        = rev_sorted_ixes.first().copied().unwrap_or_default();
-        sorted.reserve_exact(rev_sorted_ixes.len());
-        this.grow(1 + max_elem);
+    pub fn unchecked_topo_sort(&self, rev_sorted_keys:Vec<T>) -> Vec<T> {
+        let mut sorted      = Vec::<T>::new();
+        let mut orphans     = BTreeSet::<T>::new();
+        let mut non_orphans = BTreeSet::<T>::new();
+        let this            = self.clone().unchecked_kept_only(&rev_sorted_keys);
+        sorted.reserve_exact(rev_sorted_keys.len());
 
         let mut nodes = this.nodes;
-        for ix in rev_sorted_ixes.into_iter() {
-            if nodes[ix].ins.is_empty() { orphans.insert(ix); }
-            else                        { non_orphans.insert(ix); }
+        for key in rev_sorted_keys.into_iter() {
+            let ins_empty = nodes.get(&key).map(|t|t.ins.is_empty()) != Some(false);
+            if ins_empty { orphans.insert(key); }
+            else         { non_orphans.insert(key); }
         }
 
         loop {
-            match orphans.iter().next().copied() {
+            match orphans.iter().next().cloned() {
                 None => {
-                    match non_orphans.iter().next().copied() {
+                    match non_orphans.iter().next().cloned() {
                         None => break,
                         Some(ix) => {
                             // NON DAG
@@ -119,27 +145,23 @@ impl DependencyGraph {
                     }
                 },
                 Some(ix) => {
-                    sorted.push(ix);
+                    sorted.push(ix.clone());
                     orphans.remove(&ix);
-                    for ix2 in mem::take(&mut nodes[ix].out) {
-                        let ins = &mut nodes[ix2].ins;
-                        ins.remove_item(&ix);
-                        if ins.is_empty() && non_orphans.remove(&ix2) {
-                            orphans.insert(ix2);
+                    if let Some(node) = nodes.get_mut(&ix) {
+                        for ix2 in mem::take(&mut node.out) {
+                            if let Some(node2) = nodes.get_mut(&ix2) {
+                                let ins = &mut node2.ins;
+                                ins.remove_item(&ix);
+                                if ins.is_empty() && non_orphans.remove(&ix2) {
+                                    orphans.insert(ix2);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
         sorted
-    }
-
-    /// Grow the graph to the required size. This function will NOT shrink the graph if the provided
-    /// size is smaller than the graph size.
-    fn grow(&mut self, required_size:usize) {
-        if required_size > self.nodes.len() {
-            self.nodes.resize_with(required_size,default);
-        }
     }
 }
 
@@ -184,7 +206,7 @@ extern crate test;
 
 /// Asserts whether the graph will sort the provided slice in the same order as it was provided.
 /// Please note, that the slice is sorted in order before being sorted topologically.
-pub fn assert_valid_sort(graph:&DependencyGraph, sorted:&[usize]) {
+pub fn assert_valid_sort(graph:&DependencyGraph<usize>, sorted:&[usize]) {
     let sorted = sorted.to_vec();
     assert_eq!(graph.topo_sort(&sorted),sorted);
 }
@@ -257,9 +279,9 @@ mod benches {
     /// # Results (ms)
     ///
     ///   iters | time(ms) |
-    ///   10^3  | 0.36     |
-    ///   10^4  | 3.6      |
-    ///   10^5  | 48.7     |
+    ///   10^3  | 0.47     |
+    ///   10^4  | 5.2      |
+    ///   10^5  | 74.2     |
     #[bench]
     fn bench_ascending(b:&mut Bencher) {
         let iters     = 1_000;
@@ -272,9 +294,9 @@ mod benches {
     /// # Results (ms)
     ///
     ///   iters | time(ms) |
-    ///   10^3  | 0.37     |
-    ///   10^4  | 4.0      |
-    ///   10^5  | 55.2     |
+    ///   10^3  | 0.5      |
+    ///   10^4  | 6.2      |
+    ///   10^5  | 86.8     |
     #[bench]
     fn bench_descending(b:&mut Bencher) {
         let iters     = 1_000;
@@ -284,139 +306,3 @@ mod benches {
         b.iter(move || assert_eq!(graph.topo_sort(&out),out));
     }
 }
-
-
-
-// // =================================
-// // === Sparse Dependency Sorting ===
-// // =================================
-//
-// /// Sort the provided indexes slice according to the rules. Note, that in contrast to the
-// /// [`DependencyGraph`], the rules are provided in a sparse fashion.
-// #[allow(clippy::implicit_hasher)]
-// pub fn sparse_depth_sort
-// (indexes:&[usize], elem_above_elems:&HashMap<usize,Vec<usize>>) -> Vec<usize> {
-//
-//     // === Remove from `elem_above_elems` all indexes which are not present in `indexes` ===
-//
-//     let ids_set = HashSet::<usize>::from_iter(indexes.iter().copied());
-//     let mut elem_above_elems = elem_above_elems.clone();
-//     let mut missing = vec![];
-//     for (elem,above_elems) in &mut elem_above_elems {
-//         above_elems.retain(|id| ids_set.contains(id));
-//         if above_elems.is_empty() {
-//             missing.push(*elem);
-//         }
-//     }
-//     for id in &missing {
-//         elem_above_elems.remove(id);
-//     }
-//
-//
-//     // === Generate `elem_below_elems` map ===
-//
-//     let mut elem_below_elems : HashMap<usize,Vec<usize>> = HashMap::new();
-//     for (above_id,below_ids) in &elem_above_elems {
-//         for below_id in below_ids {
-//             elem_below_elems.entry(*below_id).or_default().push(*above_id);
-//         }
-//     }
-//
-//
-//     // === Sort indexes ===
-//
-//     let mut queue        = HashSet::<usize>::new();
-//     let mut sorted       = vec![];
-//     let mut newly_sorted = vec![];
-//
-//     for id in indexes {
-//         if elem_above_elems.get(id).is_some() {
-//             queue.insert(*id);
-//         } else {
-//             newly_sorted.push(*id);
-//             while !newly_sorted.is_empty() {
-//                 let id = newly_sorted.pop().unwrap();
-//                 sorted.push(id);
-//                 elem_below_elems.remove(&id).for_each(|above_ids| {
-//                     for above_id in above_ids {
-//                         if let Some(lst) = elem_above_elems.get_mut(&above_id) {
-//                             lst.remove_item(&id);
-//                             if lst.is_empty() && queue.contains(&above_id) {
-//                                 queue.remove(&above_id);
-//                                 newly_sorted.push(above_id);
-//                             }
-//                             if lst.is_empty() {
-//                                 elem_above_elems.remove(&above_id);
-//                             }
-//                         }
-//                     }
-//                 })
-//             }
-//         }
-//     }
-//     sorted
-// }
-//
-//
-//
-// // =============
-// // === Tests ===
-// // =============
-//
-// #[cfg(test)]
-// mod sparse_tests {
-//     use super::*;
-//
-//     #[test]
-//     fn identity_with_no_rules() {
-//         assert_eq!( sparse_depth_sort(&vec![]      , &default()) , Vec::<usize>::new() );
-//         assert_eq!( sparse_depth_sort(&vec![1]     , &default()) , vec![1] );
-//         assert_eq!( sparse_depth_sort(&vec![1,3]   , &default()) , vec![1,3] );
-//         assert_eq!( sparse_depth_sort(&vec![1,2,3] , &default()) , vec![1,2,3] );
-//     }
-//
-//     #[test]
-//     fn chained_rules() {
-//         let mut rules = HashMap::<usize,Vec<usize>>::new();
-//         rules.insert(1,vec![2]);
-//         rules.insert(2,vec![3]);
-//         assert_eq!( sparse_depth_sort(&vec![]      , &rules) , Vec::<usize>::new() );
-//         assert_eq!( sparse_depth_sort(&vec![1]     , &rules) , vec![1] );
-//         assert_eq!( sparse_depth_sort(&vec![1,2]   , &rules) , vec![2,1] );
-//         assert_eq!( sparse_depth_sort(&vec![1,2,3] , &rules) , vec![3,2,1] );
-//     }
-//
-//     #[test]
-//     fn order_preserving() {
-//         let mut rules = HashMap::<usize,Vec<usize>>::new();
-//         rules.insert(1,vec![2]);
-//         rules.insert(2,vec![3]);
-//         assert_eq!( sparse_depth_sort(&vec![10,11,12]          , &rules) , vec![10,11,12] );
-//         assert_eq!( sparse_depth_sort(&vec![10,1,11,12]        , &rules) , vec![10,1,11,12] );
-//         assert_eq!( sparse_depth_sort(&vec![10,1,11,2,12]      , &rules) , vec![10,11,2,1,12] );
-//         assert_eq!( sparse_depth_sort(&vec![10,1,11,2,12,3,13] , &rules) , vec![10,11,12,3,2,1,13] );
-//     }
-// }
-//
-//
-// #[cfg(test)]
-// mod sparse_benches {
-//     use super::*;
-//     use test::Bencher;
-//
-//     /// # Results (ms)
-//     ///
-//     ///   iters | time(ms) |
-//     ///   10^3  | 0.5      |
-//     ///   10^4  | 6.3      |
-//     ///   10^5  | 101.5    |
-//     #[bench]
-//     fn bench_ascending(b:&mut Bencher) {
-//         let iters     = 1_000;
-//         let ins       = (0..iters).collect_vec();
-//         let out       = ins.clone();
-//         let mut rules = HashMap::<usize,Vec<usize>>::new();
-//         for (i,j) in out.iter().zip(out.iter().skip(1)) { rules.insert(*j,vec![*i]); }
-//         b.iter(move || assert_eq!(sparse_depth_sort(&ins,&rules),out));
-//     }
-// }

--- a/src/data/src/dependency_graph.rs
+++ b/src/data/src/dependency_graph.rs
@@ -229,6 +229,7 @@ impl<T:Ord> Extend<(T,Node<T>)> for DependencyGraph<T> {
 
 /// Utility macro allowing easy construction of the [`DependencyGraph`]. The following code:
 /// ```
+/// use crate::enso_data::dependency_graph;
 /// dependency_graph!(1->2, 2->3);
 /// ```
 /// will produce:
@@ -241,11 +242,11 @@ impl<T:Ord> Extend<(T,Node<T>)> for DependencyGraph<T> {
 /// }
 /// ```
 #[macro_export]
-macro_rules! dependency_graph {
+    macro_rules! dependency_graph {
     ($($fst:tt -> $snd:tt),* $(,)?) => {
         {
             #[allow(unused_mut)]
-            let mut graph = DependencyGraph::new();
+            let mut graph = $crate::dependency_graph::DependencyGraph::new();
             $(graph.insert_dependency($fst,$snd);)*
             graph
         }

--- a/src/data/src/dependency_graph.rs
+++ b/src/data/src/dependency_graph.rs
@@ -84,7 +84,7 @@ impl<T:Clone+Eq+Hash+Ord> DependencyGraph<T> {
     /// Removes all (incoming and outgoing) dependencies from nodes whose indexes do not belong to
     /// the provided slice.
     pub fn keep_only(&mut self, keys:&[T]) {
-        self.unchecked_keep_only_x(keys.iter().cloned().sorted())
+        self.unchecked_keep_only(keys.iter().cloned().sorted())
     }
 
     /// Removes all (incoming and outgoing) dependencies from nodes whose indexes do not belong to
@@ -95,7 +95,7 @@ impl<T:Clone+Eq+Hash+Ord> DependencyGraph<T> {
     }
 
     /// Just like [`keep_only`], but the provided slice must be sorted.
-    pub fn unchecked_keep_only_x(&mut self, sorted_keys:impl IntoIterator<Item=T>) {
+    pub fn unchecked_keep_only(&mut self, sorted_keys:impl IntoIterator<Item=T>) {
         let mut keep         = sorted_keys.into_iter();
         let mut next_to_keep = keep.next();
         let     keys         = self.nodes.keys().cloned().collect_vec();
@@ -127,8 +127,8 @@ impl<T:Clone+Eq+Hash+Ord> DependencyGraph<T> {
     }
 
     /// Just like [`kept_only`], but the provided slice must be sorted.
-    pub fn unchecked_kept_only_x(mut self, sorted_keys:impl IntoIterator<Item=T>) -> Self {
-        self.unchecked_keep_only_x(sorted_keys);
+    pub fn unchecked_kept_only(mut self, sorted_keys:impl IntoIterator<Item=T>) -> Self {
+        self.unchecked_keep_only(sorted_keys);
         self
     }
 
@@ -136,26 +136,26 @@ impl<T:Clone+Eq+Hash+Ord> DependencyGraph<T> {
     /// In case the graph is not a DAG, it will still be sorted by breaking cycles on elements with
     /// the smallest index.
     pub fn topo_sort(&self, keys:&[T]) -> Vec<T> {
-        self.unchecked_topo_sort_x(keys.iter().cloned().sorted().collect_vec())
+        self.unchecked_topo_sort(keys.iter().cloned().sorted().collect_vec())
     }
 
     /// Just like [`topo_sort`], but consumes the current dependency graph instead of cloning it.
-    pub fn into_topo_sort_x(self, keys:&[T]) -> Vec<T> {
-        self.into_unchecked_topo_sort_x(keys.iter().cloned().sorted().collect_vec())
+    pub fn into_topo_sort(self, keys:&[T]) -> Vec<T> {
+        self.into_unchecked_topo_sort(keys.iter().cloned().sorted().collect_vec())
     }
 
     /// Just like [`topo_sort`], but the provided slice must be sorted.
-    pub fn unchecked_topo_sort_x(&self, sorted_keys:Vec<T>) -> Vec<T> {
-        self.clone().into_unchecked_topo_sort_x(sorted_keys)
+    pub fn unchecked_topo_sort(&self, sorted_keys:Vec<T>) -> Vec<T> {
+        self.clone().into_unchecked_topo_sort(sorted_keys)
     }
 
     /// Just like [`unchecked_topo_sort`], bbut consumes the current dependency graph instead of
     /// cloning it.
-    pub fn into_unchecked_topo_sort_x(self, sorted_keys:Vec<T>) -> Vec<T> {
+    pub fn into_unchecked_topo_sort(self, sorted_keys:Vec<T>) -> Vec<T> {
         let mut sorted      = Vec::<T>::new();
         let mut orphans     = BTreeSet::<T>::new();
         let mut non_orphans = BTreeSet::<T>::new();
-        let this            = self.unchecked_kept_only_x(sorted_keys.iter().cloned());
+        let this            = self.unchecked_kept_only(sorted_keys.iter().cloned());
         sorted.reserve_exact(sorted_keys.len());
 
         let mut nodes = this.nodes;

--- a/src/data/src/dependency_graph.rs
+++ b/src/data/src/dependency_graph.rs
@@ -1,0 +1,421 @@
+use crate::prelude::*;
+
+use std::collections::BTreeSet;
+
+
+
+// ============
+// === Node ===
+// ============
+
+/// A dependency graph node. Registers all incoming and outgoing edges.
+#[derive(Clone,Debug,Default)]
+#[allow(missing_docs)]
+pub struct Node {
+    pub ins : Vec<usize>,
+    pub out : Vec<usize>,
+}
+
+
+
+// =======================
+// === DependencyGraph ===
+// =======================
+
+/// Dependency graph keeping track of [`Node`]s and their dependencies.
+///
+/// The graph is not sparse, which means, that if there is a dependency to node of index `X`, the
+/// graph will contain at least `X+1` nodes. Instead, you are allowed to topologically sort only a
+/// subset of the graph.
+///
+/// This decision was dictated by the use cases of this structure. It is used to record dependencies
+/// of display elements, however, in case you remove a display element, its depth-sorting
+/// information should remain intact.
+#[derive(Clone,Debug,Default)]
+pub struct DependencyGraph {
+    nodes : Vec<Node>
+}
+
+impl DependencyGraph {
+    /// Constructor.
+    pub fn new() -> Self {
+        default()
+    }
+
+    /// Insert a new dependency to the graph.
+    pub fn insert_dependency(&mut self, first:usize, second:usize) {
+        self.grow(1 + first.max(second));
+        self.nodes[first].out.push(second);
+        self.nodes[second].ins.push(first);
+    }
+
+    /// Removes all dependencies from nodes whose indexes do not belong to the provided slice.
+    pub fn keep_only(&mut self, ixes:&[usize]) {
+        self.unchecked_keep_only(&ixes.iter().copied().sorted().rev().collect_vec())
+    }
+
+    /// Removes all dependencies from nodes whose indexes do not belong to the provided slice.
+    pub fn kept_only(mut self, ixes:&[usize]) -> Self {
+        self.keep_only(ixes);
+        self
+    }
+
+    /// Just like [`keep_only`], but the provided slice must be sorted in reversed order.
+    pub fn unchecked_keep_only(&mut self, rev_sorted_ixes:&[usize]) {
+        let mut keep         = rev_sorted_ixes.to_vec();
+        let mut next_to_keep = keep.pop();
+        for ix in 0..self.nodes.len() {
+            if next_to_keep == Some(ix) {
+                next_to_keep = keep.pop();
+            } else {
+                let node = mem::take(&mut self.nodes[ix]);
+                for ix2 in node.ins { self.nodes[ix2].out.remove(ix); }
+                for ix2 in node.out { self.nodes[ix2].ins.remove(ix); }
+            }
+        }
+    }
+
+    /// Just like [`kept_only`], but the provided slice must be sorted in reversed order.
+    pub fn unchecked_kept_only(mut self, rev_sorted_ixes:&[usize]) -> Self {
+        self.unchecked_keep_only(rev_sorted_ixes);
+        self
+    }
+
+    /// Sorts the provided indexes in topological order based on the rules recorded in the graph.
+    /// In case the graph is not a DAG, it will still be sorted by breaking cycles on elements with
+    /// the smallest index.
+    pub fn topo_sort(&self, ixes:&[usize]) -> Vec<usize> {
+        self.unchecked_topo_sort(ixes.iter().copied().sorted().rev().collect_vec())
+    }
+
+    /// Just like [`topo_sort`], but the provided slice must be sorted in reversed order.
+    pub fn unchecked_topo_sort(&self, rev_sorted_ixes:Vec<usize>) -> Vec<usize> {
+        let mut sorted      = Vec::<usize>::new();
+        let mut orphans     = BTreeSet::<usize>::new();
+        let mut non_orphans = BTreeSet::<usize>::new();
+        let mut this        = self.clone().unchecked_kept_only(&rev_sorted_ixes);
+        let max_elem        = rev_sorted_ixes.first().copied().unwrap_or_default();
+        sorted.reserve_exact(rev_sorted_ixes.len());
+        this.grow(1 + max_elem);
+
+        let mut nodes = this.nodes;
+        for ix in rev_sorted_ixes.into_iter() {
+            if nodes[ix].ins.is_empty() { orphans.insert(ix); }
+            else                        { non_orphans.insert(ix); }
+        }
+
+        loop {
+            match orphans.iter().next().copied() {
+                None => {
+                    match non_orphans.iter().next().copied() {
+                        None => break,
+                        Some(ix) => {
+                            // NON DAG
+                            non_orphans.remove(&ix);
+                            orphans.insert(ix);
+                        }
+                    }
+                },
+                Some(ix) => {
+                    sorted.push(ix);
+                    orphans.remove(&ix);
+                    for ix2 in mem::take(&mut nodes[ix].out) {
+                        let ins = &mut nodes[ix2].ins;
+                        ins.remove_item(&ix);
+                        if ins.is_empty() {
+                            if non_orphans.remove(&ix2) {
+                                orphans.insert(ix2);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        sorted
+    }
+
+    /// Grow the graph to the required size. This function will NOT shrink the graph if the provided
+    /// size is smaller than the graph size.
+    fn grow(&mut self, required_size:usize) {
+        if required_size > self.nodes.len() {
+            self.nodes.resize_with(required_size,default);
+        }
+    }
+}
+
+
+
+// ==============
+// === Macros ===
+// ==============
+
+/// Utility macro allowing easy construction of the [`DependencyGraph`]. The following code:
+/// ```
+/// dependency_graph!(1->2, 2->3);
+/// ```
+/// will produce:
+/// ```ignore
+/// {
+///     let mut graph = DependencyGraph::new();
+///     graph.insert_dependency(1,2);
+///     graph.insert_dependency(2,3);
+///     graph
+/// }
+/// ```
+#[macro_export]
+macro_rules! dependency_graph {
+    ($($fst:tt -> $snd:tt),* $(,)?) => {
+        {
+            #[allow(unused_mut)]
+            let mut graph = DependencyGraph::new();
+            $(graph.insert_dependency($fst,$snd);)*
+            graph
+        }
+    };
+}
+
+
+
+// =============
+// === Tests ===
+// =============
+
+extern crate test;
+
+/// Asserts whether the graph will sort the provided slice in the same order as it was provided.
+/// Please note, that the slice is sorted in order before being sorted topologically.
+pub fn assert_valid_sort(graph:&DependencyGraph, sorted:&[usize]) {
+    let sorted = sorted.to_vec();
+    assert_eq!(graph.topo_sort(&sorted),sorted);
+}
+
+/// The same as [`assert_valid_sort`] but with a shorter syntax. Learn more about it by looking at
+/// its usage below.
+macro_rules! assert_valid_sort {
+    ($($sorted:tt for {$($rules:tt)*})*) => {
+        $({
+            let graph = dependency_graph!{$($rules)*};
+            assert_valid_sort(&graph,&$sorted);
+        })*
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity() {
+        assert_valid_sort!{
+            []        for {}
+            [0]       for {}
+            [0,1]     for {}
+            [0,1,2]   for {}
+            [0,1,2,3] for {}
+        }
+    }
+
+    #[test]
+    fn test_non_overlapping_rules() {
+        assert_valid_sort!{
+            [1,0]     for {1->0}
+            [0,2,1,3] for {2->1}
+            [1,0,3,2] for {1->0,3->2}
+        }
+    }
+
+    #[test]
+    fn test_overlapping_rules() {
+        assert_valid_sort!{
+            [4,3,2,1,0]       for {4->3,3->2,2->1,1->0}
+            [4,3,2,1,0]       for {3->2,4->3,1->0,2->1}
+            [4,3,2,1,0]       for {1->0,2->1,3->2,4->3}
+            [1,8,2,7,3,6,4,5] for {1->8,8->2,2->7,7->3,3->6,6->4,4->5}
+        }
+    }
+
+    #[test]
+    fn test_non_dag() {
+        assert_valid_sort!{
+            [0]     for {0->0}
+            [1,2,0] for {0->0}
+            [0,2,1] for {1->1}
+            [0,1,2] for {2->2}
+            [0,1]   for {0->1,1->0}
+            [0,1,2] for {0->1,1->2,2->0}
+            [0,1,2] for {0->0,0->1,0->2,1->0,1->1,1->2,2->0,2->1,2->2}
+        }
+    }
+}
+
+#[cfg(test)]
+mod benches {
+    use super::*;
+    use test::Bencher;
+
+    /// # Results (ms)
+    ///
+    ///   iters | time(ms) |
+    ///   10^3  | 0.36     |
+    ///   10^4  | 3.6      |
+    ///   10^5  | 48.7     |
+    #[bench]
+    fn bench_ascending(b:&mut Bencher) {
+        let iters     = 1_000;
+        let out       = (0..iters).collect_vec();
+        let mut graph = DependencyGraph::new();
+        for (i,j) in out.iter().zip(out.iter().skip(1)) { graph.insert_dependency(*i,*j); }
+        b.iter(move || assert_eq!(graph.topo_sort(&out),out));
+    }
+
+    /// # Results (ms)
+    ///
+    ///   iters | time(ms) |
+    ///   10^3  | 0.37     |
+    ///   10^4  | 4.0      |
+    ///   10^5  | 55.2     |
+    #[bench]
+    fn bench_descending(b:&mut Bencher) {
+        let iters     = 1_000;
+        let out       = (0..iters).rev().collect_vec();
+        let mut graph = DependencyGraph::new();
+        for (i,j) in out.iter().zip(out.iter().skip(1)) { graph.insert_dependency(*i,*j); }
+        b.iter(move || assert_eq!(graph.topo_sort(&out),out));
+    }
+}
+
+
+
+// =================================
+// === Sparse Dependency Sorting ===
+// =================================
+
+/// Sort the provided indexes slice according to the rules. Note, that in contrast to the
+/// [`DependencyGraph`], the rules are provided in a sparse fashion.
+#[allow(clippy::implicit_hasher)]
+pub fn sparse_depth_sort
+(indexes:&[usize], elem_above_elems:&HashMap<usize,Vec<usize>>) -> Vec<usize> {
+
+    // === Remove from `elem_above_elems` all indexes which are not present in `indexes` ===
+
+    let ids_set = HashSet::<usize>::from_iter(indexes.iter().copied());
+    let mut elem_above_elems = elem_above_elems.clone();
+    let mut missing = vec![];
+    for (elem,above_elems) in &mut elem_above_elems {
+        above_elems.retain(|id| ids_set.contains(id));
+        if above_elems.is_empty() {
+            missing.push(*elem);
+        }
+    }
+    for id in &missing {
+        elem_above_elems.remove(id);
+    }
+
+
+    // === Generate `elem_below_elems` map ===
+
+    let mut elem_below_elems : HashMap<usize,Vec<usize>> = HashMap::new();
+    for (above_id,below_ids) in &elem_above_elems {
+        for below_id in below_ids {
+            elem_below_elems.entry(*below_id).or_default().push(*above_id);
+        }
+    }
+
+
+    // === Sort indexes ===
+
+    let mut queue        = HashSet::<usize>::new();
+    let mut sorted       = vec![];
+    let mut newly_sorted = vec![];
+
+    for id in indexes {
+        if elem_above_elems.get(id).is_some() {
+            queue.insert(*id);
+        } else {
+            newly_sorted.push(*id);
+            while !newly_sorted.is_empty() {
+                let id = newly_sorted.pop().unwrap();
+                sorted.push(id);
+                elem_below_elems.remove(&id).for_each(|above_ids| {
+                    for above_id in above_ids {
+                        if let Some(lst) = elem_above_elems.get_mut(&above_id) {
+                            lst.remove_item(&id);
+                            if lst.is_empty() && queue.contains(&above_id) {
+                                queue.remove(&above_id);
+                                newly_sorted.push(above_id);
+                            }
+                            if lst.is_empty() {
+                                elem_above_elems.remove(&above_id);
+                            }
+                        }
+                    }
+                })
+            }
+        }
+    }
+    sorted
+}
+
+
+
+// =============
+// === Tests ===
+// =============
+
+#[cfg(test)]
+mod sparse_tests {
+    use super::*;
+
+    #[test]
+    fn identity_with_no_rules() {
+        assert_eq!( sparse_depth_sort(&vec![]      , &default()) , Vec::<usize>::new() );
+        assert_eq!( sparse_depth_sort(&vec![1]     , &default()) , vec![1] );
+        assert_eq!( sparse_depth_sort(&vec![1,3]   , &default()) , vec![1,3] );
+        assert_eq!( sparse_depth_sort(&vec![1,2,3] , &default()) , vec![1,2,3] );
+    }
+
+    #[test]
+    fn chained_rules() {
+        let mut rules = HashMap::<usize,Vec<usize>>::new();
+        rules.insert(1,vec![2]);
+        rules.insert(2,vec![3]);
+        assert_eq!( sparse_depth_sort(&vec![]      , &rules) , Vec::<usize>::new() );
+        assert_eq!( sparse_depth_sort(&vec![1]     , &rules) , vec![1] );
+        assert_eq!( sparse_depth_sort(&vec![1,2]   , &rules) , vec![2,1] );
+        assert_eq!( sparse_depth_sort(&vec![1,2,3] , &rules) , vec![3,2,1] );
+    }
+
+    #[test]
+    fn order_preserving() {
+        let mut rules = HashMap::<usize,Vec<usize>>::new();
+        rules.insert(1,vec![2]);
+        rules.insert(2,vec![3]);
+        assert_eq!( sparse_depth_sort(&vec![10,11,12]          , &rules) , vec![10,11,12] );
+        assert_eq!( sparse_depth_sort(&vec![10,1,11,12]        , &rules) , vec![10,1,11,12] );
+        assert_eq!( sparse_depth_sort(&vec![10,1,11,2,12]      , &rules) , vec![10,11,2,1,12] );
+        assert_eq!( sparse_depth_sort(&vec![10,1,11,2,12,3,13] , &rules) , vec![10,11,12,3,2,1,13] );
+    }
+}
+
+
+#[cfg(test)]
+mod sparse_benches {
+    use super::*;
+    use test::Bencher;
+
+    /// # Results (ms)
+    ///
+    ///   iters | time(ms) |
+    ///   10^3  | 0.5      |
+    ///   10^4  | 6.3      |
+    ///   10^5  | 101.5    |
+    #[bench]
+    fn bench_ascending(b:&mut Bencher) {
+        let iters     = 1_000;
+        let ins       = (0..iters).collect_vec();
+        let out       = ins.clone();
+        let mut rules = HashMap::<usize,Vec<usize>>::new();
+        for (i,j) in out.iter().zip(out.iter().skip(1)) { rules.insert(*j,vec![*i]); }
+        b.iter(move || assert_eq!(sparse_depth_sort(&ins,&rules),out));
+    }
+}

--- a/src/data/src/dependency_graph.rs
+++ b/src/data/src/dependency_graph.rs
@@ -1,3 +1,5 @@
+//! A dependency graph implementation optimized for sorting depth-indexed components.
+
 use crate::prelude::*;
 
 use std::collections::BTreeSet;

--- a/src/data/src/lib.rs
+++ b/src/data/src/lib.rs
@@ -1,8 +1,9 @@
 //! Library of general data structures.
 
 #![feature(associated_type_bounds)]
-#![feature(trait_alias)]
 #![feature(test)]
+#![feature(trait_alias)]
+#![feature(vec_remove_item)]
 
 #![deny(unconditional_recursion)]
 
@@ -14,6 +15,7 @@
 #![warn(unsafe_code)]
 #![warn(unused_import_braces)]
 
+pub mod dependency_graph;
 pub mod hash_map_tree;
 pub mod index;
 pub mod diet;

--- a/src/data/src/opt_vec.rs
+++ b/src/data/src/opt_vec.rs
@@ -80,6 +80,10 @@ impl<T,I:Index> OptVec<T,I> {
 
     /// Finds a free index and inserts the element. The index is re-used in case the array is sparse
     /// or is added in case of no free places.
+    ///
+    /// This code is very similar to [`insert_with_ix_`]. We duplicate it in order to be sure that
+    /// it will be correctly optimized as it is used in a very performance sensitive algorithms of
+    /// managing GPU buffers.
     pub fn insert_with_ix<S,F>(&mut self, f:F) -> (I,S)
     where F : FnOnce(I) -> (T,S) {
         match self.free_ixs.pop() {
@@ -100,6 +104,10 @@ impl<T,I:Index> OptVec<T,I> {
     /// Finds a free index and inserts the element. The index is re-used in case the array is sparse
     /// or is added in case of no free places. The used lambda does not return any value to the call
     /// scope of this function. See [`insert_with_ix`] for a more generic solution.
+    ///
+    /// This code is very similar to [`insert_with_ix`]. We duplicate it in order to be sure that
+    /// it will be correctly optimized as it is used in a very performance sensitive algorithms of
+    /// managing GPU buffers.
     pub fn insert_with_ix_<F>(&mut self, f:F) -> I
     where F : FnOnce(I) -> T {
         match self.free_ixs.pop() {

--- a/src/data/src/opt_vec.rs
+++ b/src/data/src/opt_vec.rs
@@ -75,12 +75,33 @@ impl<T,I:Index> OptVec<T,I> {
 impl<T,I:Index> OptVec<T,I> {
     /// Inserts the provided element to the vector. It reuses free indexes if any.
     pub fn insert(&mut self, item: T) -> I {
-        self.insert_with_ix(|_| item)
+        self.insert_with_ix_(|_| item)
     }
 
     /// Finds a free index and inserts the element. The index is re-used in case the array is sparse
     /// or is added in case of no free places.
-    pub fn insert_with_ix<F:FnOnce(I) -> T>(&mut self, f: F) -> I {
+    pub fn insert_with_ix<S,F>(&mut self, f:F) -> (I,S)
+    where F : FnOnce(I) -> (T,S) {
+        match self.free_ixs.pop() {
+            None => {
+                let index = self.items.len().into();
+                let (item,out) = f(index);
+                self.items.push(Some(item));
+                (index,out)
+            }
+            Some(index) => {
+                let (item,out) = f(index);
+                self.items[index.into()] = Some(item);
+                (index,out)
+            }
+        }
+    }
+
+    /// Finds a free index and inserts the element. The index is re-used in case the array is sparse
+    /// or is added in case of no free places. The used lambda does not return any value to the call
+    /// scope of this function. See [`insert_with_ix`] for a more generic solution.
+    pub fn insert_with_ix_<F>(&mut self, f:F) -> I
+    where F : FnOnce(I) -> T {
         match self.free_ixs.pop() {
             None => {
                 let index = self.items.len().into();

--- a/src/logger/src/macros.rs
+++ b/src/logger/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! log_template {
     };
 
     ($expand:ident, $level:path, $logger:expr, $msg:tt) => {
-        $crate::LoggerOps::<$level>::log(&$logger,$level,iformat!($msg))
+        $crate::LoggerOps::<$level>::log(&$logger,$level,||iformat!($msg))
     };
 
     ($expand:ident, $level:path, $logger:expr, || $msg:expr) => {
@@ -34,7 +34,7 @@ macro_rules! log_template {
     };
 
     ($expand:ident, $level:path, $logger:expr, $msg:tt, || $($body:tt)*) => {
-        $crate::log_template_group!($expand,$level,$logger,[iformat!($msg)],||$($body)*)
+        $crate::log_template_group!($expand,$level,$logger,[||iformat!($msg)],||$($body)*)
     };
 
     ($expand:ident, $level:path, $logger:expr, || $msg:expr, || $($body:tt)*) => {

--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-prelude"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 
@@ -39,12 +39,17 @@ wasm-bindgen = { version = "=0.2.58" , features = ["nightly"] }
 # TODO: should be behind a flag, as the `nalgebra` package is pretty big and this crate would be
 #       also useful for projects which do not require `nalgebra`.
 nalgebra     = "0.21.1"
-# TODO[ao] anyhow 1.0.38 breaks clippy on our current rustc. Remove after switching to new Rust 
-#       toolchain version (this is not our dependency).
+# TODO[ao] those dependencies at newest versions breaks clippy on our current rustc Remove after switching to
+#       new Rust toolchain version (those are not our dependencies).
 anyhow       = { version = "<=1.0.37" }
+bumpalo      = { version = "=3.4.0"  }
+object       = { version = "=0.21.1" }
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-backtrace = "0.3.53"
+# TODO[ao] the newest backtrace breaks compilation on our current rustc. Remove = once switched to the new Rust
+#      toolchain
+backtrace = "=0.3.53"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -42,9 +42,6 @@ nalgebra     = "0.21.1"
 # TODO[ao] anyhow 1.0.38 breaks clippy on our current rustc. Remove after switching to new Rust 
 #       toolchain version (this is not our dependency).
 anyhow       = { version = "<=1.0.37" }
-# TODO[ao] anyhow 1.0.38 breaks clippy on our current rustc. Remove after switching to new Rust
-#       toolchain version (this is not our dependency).
-bumpalo       = { version = "<=3.4.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = "0.3.53"

--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -42,6 +42,9 @@ nalgebra     = "0.21.1"
 # TODO[ao] anyhow 1.0.38 breaks clippy on our current rustc. Remove after switching to new Rust 
 #       toolchain version (this is not our dependency).
 anyhow       = { version = "<=1.0.37" }
+# TODO[ao] anyhow 1.0.38 breaks clippy on our current rustc. Remove after switching to new Rust
+#       toolchain version (this is not our dependency).
+bumpalo       = { version = "<=3.4.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = "0.3.53"

--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-prelude"
-version = "0.1.10"
+version = "0.1.9"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-prelude"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/prelude/src/clone.rs
+++ b/src/prelude/src/clone.rs
@@ -79,6 +79,8 @@ impl_clone_ref_as_clone_no_from!(f32);
 impl_clone_ref_as_clone_no_from!(f64);
 impl_clone_ref_as_clone_no_from!(i32);
 impl_clone_ref_as_clone_no_from!(i64);
+impl_clone_ref_as_clone_no_from!(u32);
+impl_clone_ref_as_clone_no_from!(u64);
 impl_clone_ref_as_clone_no_from!(usize);
 impl_clone_ref_as_clone_no_from!([T] PhantomData<T>);
 impl_clone_ref_as_clone_no_from!([T:?Sized] Rc<T>);

--- a/src/prelude/src/clone.rs
+++ b/src/prelude/src/clone.rs
@@ -82,6 +82,7 @@ impl_clone_ref_as_clone_no_from!(i64);
 impl_clone_ref_as_clone_no_from!(u32);
 impl_clone_ref_as_clone_no_from!(u64);
 impl_clone_ref_as_clone_no_from!(usize);
+impl_clone_ref_as_clone_no_from!(std::any::TypeId);
 impl_clone_ref_as_clone_no_from!([T] PhantomData<T>);
 impl_clone_ref_as_clone_no_from!([T:?Sized] Rc<T>);
 impl_clone_ref_as_clone_no_from!([T:?Sized] Weak<T>);

--- a/src/prelude/src/macros.rs
+++ b/src/prelude/src/macros.rs
@@ -172,6 +172,22 @@ macro_rules! f_ {
     };
 }
 
+/// Variant of the `f` macro producing a lambda which drops its first and second arguments.
+#[macro_export]
+macro_rules! f__ {
+    ([$($name:ident),*] $($expr:tt)*) => {
+        f! { [$($name),*] (_,_) $($expr)*  }
+    };
+
+    ($name:ident . $($toks:tt)*) => {
+        f__! { [$name] $name . $($toks)* }
+    };
+
+    ( { $name:ident . $($toks:tt)* } ) => {
+        f__! { [$name] { $name . $($toks)* } }
+    };
+}
+
 /// A macro for use in situations where the code is unreachable.
 ///
 /// This macro will panic in debug builds, but in release builds it expands to

--- a/src/shapely/impl/Cargo.toml
+++ b/src/shapely/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-shapely"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/shapely/impl/Cargo.toml
+++ b/src/shapely/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-shapely"
-version = "0.1.4"
+version = "0.1.3"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/shapely/impl/src/lib.rs
+++ b/src/shapely/impl/src/lib.rs
@@ -85,7 +85,7 @@ macro_rules! newtype_prim_no_derives {
 
         impl $name {
             /// Constructor.
-            pub fn new(raw:$type) -> Self {
+            pub const fn new(raw:$type) -> Self {
                 Self {raw}
             }
         }

--- a/src/shapely/impl/src/lib.rs
+++ b/src/shapely/impl/src/lib.rs
@@ -39,47 +39,78 @@ macro_rules! replace {
 /// including Copy, Clone, Debug, Default, Display, From, Into, Deref, and DerefMut.
 ///
 /// For the following input:
-/// ```compile_fail
-/// newtype_copy! {
-///     AttributeIndex(usize)
+/// ```ignore
+/// newtype_prim! {
+///     AttributeIndex(usize);
 /// }
 /// ```
 ///
 /// The following code is generated:
-/// ```compile_fail
-/// #[derive(Copy, Clone, Debug, Default, Display, From, Into)]
-/// pub struct AttributeIndex(usize);
+/// ```ignore
+/// #[derive(Copy,Clone,CloneRef,Debug,Default,Display,Eq,Hash,Ord,PartialOrd,PartialEq)]
+/// pub struct AttributeIndex {
+///     raw: usize
+/// }
+/// impl AttributeIndex {
+///     /// Constructor.
+///     pub fn new(raw:usize) -> Self {
+///         Self { raw }
+///     }
+/// }
 /// impl Deref for AttributeIndex {
 ///     type Target = usize;
 ///     fn deref(&self) -> &Self::Target {
-///         &self.0
+///         &self.raw
 ///     }
 /// }
 /// impl DerefMut for AttributeIndex {
 ///     fn deref_mut(&mut self) -> &mut Self::Target {
-///         &mut self.0
+///         &mut self.raw
 ///     }
 /// }
+/// impl From<usize>   for AttributeIndex { fn from(t:usize)   -> Self { Self::new(t)   } }
+/// impl From<&usize>  for AttributeIndex { fn from(t:&usize)  -> Self { Self::new(*t)  } }
+/// impl From<&&usize> for AttributeIndex { fn from(t:&&usize) -> Self { Self::new(**t) } }
+/// impl From<AttributeIndex>   for usize { fn from(t:AttributeIndex)   -> Self { t.raw } }
+/// impl From<&AttributeIndex>  for usize { fn from(t:&AttributeIndex)  -> Self { t.raw } }
+/// impl From<&&AttributeIndex> for usize { fn from(t:&&AttributeIndex) -> Self { t.raw } }
 /// ```
 #[macro_export]
-macro_rules! newtype_copy {
+macro_rules! newtype_prim {
     ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {$(
         $(#$meta)*
-        #[derive(Copy,Clone,CloneRef,Debug,Default,Display,Eq,From,Into,Ord,PartialOrd,PartialEq)]
-        pub struct $name($type);
+        #[derive(Copy,Clone,CloneRef,Debug,Default,Display,Eq,Hash,Ord,PartialOrd,PartialEq)]
+        pub struct $name {
+            raw:$type
+        }
+
+        impl $name {
+            /// Constructor.
+            pub fn new(raw:$type) -> Self {
+                Self {raw}
+            }
+        }
 
         impl Deref for $name {
             type Target = $type;
             fn deref(&self) -> &Self::Target {
-                &self.0
+                &self.raw
             }
         }
 
         impl DerefMut for $name {
             fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+                &mut self.raw
             }
         }
+
+        impl From<$type>   for $name { fn from(t:$type)   -> Self { Self::new(t)   } }
+        impl From<&$type>  for $name { fn from(t:&$type)  -> Self { Self::new(*t)  } }
+        impl From<&&$type> for $name { fn from(t:&&$type) -> Self { Self::new(**t) } }
+
+        impl From<$name>   for $type { fn from(t:$name)   -> Self { t.raw } }
+        impl From<&$name>  for $type { fn from(t:&$name)  -> Self { t.raw } }
+        impl From<&&$name> for $type { fn from(t:&&$name) -> Self { t.raw } }
     )*}
 }
 

--- a/src/shapely/impl/src/lib.rs
+++ b/src/shapely/impl/src/lib.rs
@@ -76,10 +76,9 @@ macro_rules! replace {
 /// impl From<&&AttributeIndex> for usize { fn from(t:&&AttributeIndex) -> Self { t.raw } }
 /// ```
 #[macro_export]
-macro_rules! newtype_prim {
+macro_rules! newtype_prim_no_derives {
     ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {$(
         $(#$meta)*
-        #[derive(Copy,Clone,CloneRef,Debug,Default,Display,Eq,Hash,Ord,PartialOrd,PartialEq)]
         pub struct $name {
             raw:$type
         }
@@ -112,6 +111,45 @@ macro_rules! newtype_prim {
         impl From<&$name>  for $type { fn from(t:&$name)  -> Self { t.raw } }
         impl From<&&$name> for $type { fn from(t:&&$name) -> Self { t.raw } }
     )*}
+}
+
+#[macro_export]
+macro_rules! newtype_prim {
+    ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {
+        $crate::newtype_prim_no_derives! {
+            $(
+                $(#$meta)*
+                #[derive(Copy,Clone,CloneRef,Debug,Default,Display,Eq,Hash,Ord,PartialOrd,PartialEq)]
+                $name($type);
+            )*
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! newtype_prim_no_default {
+    ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {
+        $crate::newtype_prim_no_derives! {
+            $(
+                $(#$meta)*
+                #[derive(Copy,Clone,CloneRef,Debug,Display,Eq,Hash,Ord,PartialOrd,PartialEq)]
+                $name($type);
+            )*
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! newtype_prim_no_default_no_display {
+    ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {
+        $crate::newtype_prim_no_derives! {
+            $(
+                $(#$meta)*
+                #[derive(Copy,Clone,CloneRef,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]
+                $name($type);
+            )*
+        }
+    }
 }
 
 #[macro_export]

--- a/src/shapely/impl/src/lib.rs
+++ b/src/shapely/impl/src/lib.rs
@@ -35,6 +35,45 @@ macro_rules! replace {
     ($a:tt,$($b:tt)*) => {$($b)*}
 }
 
+/// The same as [`newtype_prim`] but does not generate derive clauses.
+#[macro_export]
+macro_rules! newtype_prim_no_derives {
+    ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {$(
+        $(#$meta)*
+        pub struct $name {
+            raw:$type
+        }
+
+        impl $name {
+            /// Constructor.
+            pub const fn new(raw:$type) -> Self {
+                Self {raw}
+            }
+        }
+
+        impl Deref for $name {
+            type Target = $type;
+            fn deref(&self) -> &Self::Target {
+                &self.raw
+            }
+        }
+
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.raw
+            }
+        }
+
+        impl From<$type>   for $name { fn from(t:$type)   -> Self { Self::new(t)   } }
+        impl From<&$type>  for $name { fn from(t:&$type)  -> Self { Self::new(*t)  } }
+        impl From<&&$type> for $name { fn from(t:&&$type) -> Self { Self::new(**t) } }
+
+        impl From<$name>   for $type { fn from(t:$name)   -> Self { t.raw } }
+        impl From<&$name>  for $type { fn from(t:&$name)  -> Self { t.raw } }
+        impl From<&&$name> for $type { fn from(t:&&$name) -> Self { t.raw } }
+    )*}
+}
+
 /// Generates a newtype wrapper for the provided types. It also generates a lot of impls,
 /// including Copy, Clone, Debug, Default, Display, From, Into, Deref, and DerefMut.
 ///
@@ -76,44 +115,6 @@ macro_rules! replace {
 /// impl From<&&AttributeIndex> for usize { fn from(t:&&AttributeIndex) -> Self { t.raw } }
 /// ```
 #[macro_export]
-macro_rules! newtype_prim_no_derives {
-    ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {$(
-        $(#$meta)*
-        pub struct $name {
-            raw:$type
-        }
-
-        impl $name {
-            /// Constructor.
-            pub const fn new(raw:$type) -> Self {
-                Self {raw}
-            }
-        }
-
-        impl Deref for $name {
-            type Target = $type;
-            fn deref(&self) -> &Self::Target {
-                &self.raw
-            }
-        }
-
-        impl DerefMut for $name {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.raw
-            }
-        }
-
-        impl From<$type>   for $name { fn from(t:$type)   -> Self { Self::new(t)   } }
-        impl From<&$type>  for $name { fn from(t:&$type)  -> Self { Self::new(*t)  } }
-        impl From<&&$type> for $name { fn from(t:&&$type) -> Self { Self::new(**t) } }
-
-        impl From<$name>   for $type { fn from(t:$name)   -> Self { t.raw } }
-        impl From<&$name>  for $type { fn from(t:&$name)  -> Self { t.raw } }
-        impl From<&&$name> for $type { fn from(t:&&$name) -> Self { t.raw } }
-    )*}
-}
-
-#[macro_export]
 macro_rules! newtype_prim {
     ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {
         $crate::newtype_prim_no_derives! {
@@ -126,6 +127,7 @@ macro_rules! newtype_prim {
     }
 }
 
+/// The same as [`newtype_prim`] but does not generate [`Default`] derive clause.
 #[macro_export]
 macro_rules! newtype_prim_no_default {
     ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {
@@ -139,6 +141,7 @@ macro_rules! newtype_prim_no_default {
     }
 }
 
+/// The same as [`newtype_prim`] but does not generate [`Default`] and [`Display`] derive clauses.
 #[macro_export]
 macro_rules! newtype_prim_no_default_no_display {
     ($( $(#$meta:tt)* $name:ident($type:ty); )*) => {


### PR DESCRIPTION
### Pull Request Description
This PR adds a dependency graph implementation optimized for sorting depth-indexed components. Also, this PR implements some generic utils in Prelude.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
