### PR TITLE
Add `map_or_default` and `map_ref_or_default` on `Option`

### DIFF
--- a/src/prelude/src/option.rs
+++ b/src/prelude/src/option.rs
@@ -3,10 +3,14 @@
 /// Adds mapping methods to the `Option` type.
 pub trait OptionOps {
     type Item;
-    fn map_none     <F>     (self  , f:F) -> Self      where F : FnOnce();
-    fn map_ref      <U,F>   (&self , f:F) -> Option<U> where F : FnOnce(&Self::Item) -> U;
-    fn for_each     <U,F>   (self  , f:F)              where F : FnOnce(Self::Item)  -> U;
-    fn for_each_ref <U,F>   (&self , f:F)              where F : FnOnce(&Self::Item) -> U;
+    fn map_none           <F>     (self  , f:F) -> Self      where F : FnOnce();
+    fn map_ref            <U,F>   (&self , f:F) -> Option<U> where F : FnOnce(&Self::Item) -> U;
+    fn map_or_default     <U,F>   (self  , f:F) -> U
+    where U : Default, F : FnOnce(Self::Item) -> U;
+    fn map_ref_or_default <U,F>   (&self , f:F) -> U
+    where U : Default, F : FnOnce(&Self::Item) -> U;
+    fn for_each           <U,F>   (self  , f:F)              where F : FnOnce(Self::Item)  -> U;
+    fn for_each_ref       <U,F>   (&self , f:F)              where F : FnOnce(&Self::Item) -> U;
     /// Returns true if option contains Some with value matching given predicate.
     fn contains_if  <F>   (&self, f:F) -> bool      where F : FnOnce(&Self::Item) -> bool;
 }
@@ -22,6 +26,14 @@ impl<T> OptionOps for Option<T> {
 
     fn map_ref<U,F>(&self, f:F) -> Option<U> where F : FnOnce(&Self::Item) -> U {
         self.as_ref().map(f)
+    }
+
+    fn map_or_default<U,F>(self, f:F) -> U where U : Default, F : FnOnce(Self::Item) -> U {
+        self.map_or_else(U::default,f)
+    }
+
+    fn map_ref_or_default<U,F>(&self, f:F) -> U where U : Default, F : FnOnce(&Self::Item) -> U {
+        self.as_ref().map_or_default(f)
     }
 
     fn for_each<U,F>(self, f:F) where F : FnOnce(Self::Item) -> U {


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
This was requested [here](https://github.com/enso-org/ide/pull/1427#discussion_r614577436) by @wdanilo.

The behavior is analogous to `map_or_else` and `map_ref`.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [ ] All code has been tested where possible.
