### PR TITLE
Workaround for Clippy ICE problem

### DIFF
--- a/src/prelude/Cargo.toml
+++ b/src/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "enso-prelude"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Enso Team <enso-dev@enso.org>"]
 edition = "2018"
 

--- a/src/prelude/src/debug/logging.rs
+++ b/src/prelude/src/debug/logging.rs
@@ -37,17 +37,29 @@ macro_rules! define_debug_macros {
             }
         }
 
-        /// Special logging macro that prints to the Web Console on wasm targets and stdout
-        /// otherwise. It is supposed to be used only for development purposes and shouldn't be
-        /// present in a production-ready code.
-        /// Macro follows `iformat` formatting convention.
-        #[macro_export] macro_rules! $upper  {
-            ($d($d arg:tt)*) => {
-                $crate::debug::logging:: $lower($crate::iformat!($d ($d arg)*))
-            }
-        }
+        // FIXME [mwu] Should be restored. See [Clippy ICE workaround]
+        // /// Special logging macro that prints to the Web Console on wasm targets and stdout
+        // /// otherwise. It is supposed to be used only for development purposes and shouldn't be
+        // /// present in a production-ready code.
+        // /// Macro follows `iformat` formatting convention.
+        // #[macro_export] macro_rules! $upper  {
+        //     ($d($d arg:tt)*) => {
+        //         $crate::debug::logging:: $lower($crate::iformat!($d ($d arg)*))
+        //     }
+        // }
     )*}
 }
+
+// FIXME [mwu] Should be removed. See [Clippy ICE workaround]
+mod manually_expanded;
+
+// Note [Clippy ICE workaround]
+// ~~~~~~~~~~~~~~~~~~~~~
+// The recent Clippy introduced ICE that happens when other crate uses debug macros in a lambda.
+// To workaround this we need to define them manually, rather than with `define_debug_macros`.
+// When https://github.com/rust-lang/rust-clippy/issues/7272 is resolved, we should bump and:
+// 1) uncomment the second part of `define_debug_macros`;
+// 2) remove the `manually_expanded` module altogether.
 
 define_debug_macros!{$
     [trace TRACE   purple]
@@ -59,6 +71,7 @@ define_debug_macros!{$
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     use wasm_bindgen_test::*;
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -80,8 +93,6 @@ mod tests {
         TRACE!("test");
         DEBUG!("Using new iformat syntax: var = " var ". Is that much?");
         INFO!("Using old iformat syntax: var = {var}. Is that much?");
-        DEBUG!("test");
-        INFO!("test");
         WARNING!("test");
         ERROR!("test");
     }

--- a/src/prelude/src/debug/logging/manually_expanded.rs
+++ b/src/prelude/src/debug/logging/manually_expanded.rs
@@ -1,0 +1,52 @@
+//! This module contains manually expanded macros that should be defined by `define_debug_macros`.
+//! See [Clippy ICE workaround] in [crate::debug::logging].
+
+/// Special logging macro that prints to the Web Console on wasm targets and stdout
+/// otherwise. It is supposed to be used only for development purposes and shouldn't be
+/// present in a production-ready code.
+/// Macro follows `iformat` formatting convention.
+#[macro_export] macro_rules! TRACE {
+    ($($arg:tt)*) => {
+        $crate::debug::logging::trace($crate::iformat!($($arg)*))
+    }
+}
+
+/// Special logging macro that prints to the Web Console on wasm targets and stdout
+/// otherwise. It is supposed to be used only for development purposes and shouldn't be
+/// present in a production-ready code.
+/// Macro follows `iformat` formatting convention.
+#[macro_export] macro_rules! DEBUG {
+    ($($arg:tt)*) => {
+        $crate::debug::logging::debug($crate::iformat!($($arg)*))
+    }
+}
+
+/// Special logging macro that prints to the Web Console on wasm targets and stdout
+/// otherwise. It is supposed to be used only for development purposes and shouldn't be
+/// present in a production-ready code.
+/// Macro follows `iformat` formatting convention.
+#[macro_export] macro_rules! INFO {
+    ($($arg:tt)*) => {
+        $crate::debug::logging::info($crate::iformat!($($arg)*))
+    }
+}
+
+/// Special logging macro that prints to the Web Console on wasm targets and stdout
+/// otherwise. It is supposed to be used only for development purposes and shouldn't be
+/// present in a production-ready code.
+/// Macro follows `iformat` formatting convention.
+#[macro_export] macro_rules! WARNING {
+    ($($arg:tt)*) => {
+        $crate::debug::logging::warn($crate::iformat!($($arg)*))
+    }
+}
+
+/// Special logging macro that prints to the Web Console on wasm targets and stdout
+/// otherwise. It is supposed to be used only for development purposes and shouldn't be
+/// present in a production-ready code.
+/// Macro follows `iformat` formatting convention.
+#[macro_export] macro_rules! ERROR {
+    ($($arg:tt)*) => {
+        $crate::debug::logging::error($crate::iformat!($($arg)*))
+    }
+}


### PR DESCRIPTION
### Pull Request Description
The IDE repository is unable to use debug macros due to a clippy ICE'ing (https://github.com/rust-lang/rust-clippy/issues/7272). Until the issue is solved in the toolchain, we should keep the debug macros manually expanded.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
