### PR TITLE
Fix bound by using opt-out

### DIFF
--- a/src/generics/src/hlist.rs
+++ b/src/generics/src/hlist.rs
@@ -72,7 +72,7 @@ pub trait HasLength {
 }
 
 /// Compile-time known length value.
-pub const fn len<T:HasLength>() -> usize {
+pub const fn len<T:?const HasLength>() -> usize {
     <T as HasLength>::LEN
 }
 

--- a/src/generics/src/lib.rs
+++ b/src/generics/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(const_fn_trait_bound)]
 #![feature(specialization)]
 #![feature(trait_alias)]
+#![feature(const_trait_bound_opt_out)]
 
 pub mod generic;
 pub mod hlist;


### PR DESCRIPTION
### Pull Request Description
This would fix a regression caused by https://github.com/rust-lang/rust/pull/87375, which would enforce a `T: const HasLength` bound on the current function

### Important Notes
The current code would break after https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md lands, so this PR fixes the issue. No significant changes to the API/logic are introduced.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guide.
- [x] All code has been tested where possible.
